### PR TITLE
Auto-create user config with SmarterMail defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Example:
 
 ```yaml
 logs_dir: /var/lib/smartermail/Logs
-staging_dir: /var/tmp/sm-tool/logs
+staging_dir: /var/tmp/sm-logtool/logs
 default_kind: smtp
 ```
 
@@ -57,7 +57,10 @@ Config resolution order:
 
 1. `--config /path/to/config.yaml`
 2. `SM_LOGTOOL_CONFIG`
-3. Repository `config.yaml`
+3. `~/.config/sm-logtool/config.yaml`
+
+When the default path is used and the file does not exist, `sm-logtool`
+creates it automatically with SmarterMail-oriented defaults.
 
 ## Usage
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,3 @@
 logs_dir: /var/lib/smartermail/Logs
-staging_dir: /var/tmp/sm-tool/logs
+staging_dir: /var/tmp/sm-logtool/logs
 default_kind: smtp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sm-logtool"
-version = "0.9.0"
+version = "0.9.1"
 description = "Interactive TUI and non-interactive CLI helper for exploring SmarterMail logs on Linux servers"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -18,6 +18,35 @@ def test_load_config_missing_file(tmp_path):
     assert app_config.default_kind == "smtp"
 
 
+def test_load_config_creates_default_config_file(tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.delenv("SM_LOGTOOL_CONFIG", raising=False)
+
+    app_config = config.load_config()
+    expected_path = home_dir / ".config" / "sm-logtool" / "config.yaml"
+
+    assert app_config.path == expected_path
+    assert app_config.exists
+    assert app_config.logs_dir == Path("/var/lib/smartermail/Logs")
+    assert app_config.staging_dir == Path("/var/tmp/sm-logtool/logs")
+    assert app_config.default_kind == "smtp"
+
+
+def test_load_config_creates_env_config_file(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "custom" / "config.yaml"
+    monkeypatch.setenv("SM_LOGTOOL_CONFIG", str(cfg_path))
+
+    app_config = config.load_config()
+
+    assert app_config.path == cfg_path
+    assert app_config.exists
+    assert app_config.logs_dir == Path("/var/lib/smartermail/Logs")
+    assert app_config.staging_dir == Path("/var/tmp/sm-logtool/logs")
+    assert app_config.default_kind == "smtp"
+
+
 def test_load_config_reads_values(tmp_path):
     cfg_path = tmp_path / "config.yaml"
     logs_dir = tmp_path / "logs"


### PR DESCRIPTION
  # Summary

  Fixes config path/default behavior for pipx/pip installs by using a user-scoped
  default config and auto-creating it on first run. Also updates docs/sample
  config and bumps patch version to 0.9.1.

  ## Related Issues

  - Closes #
  - Related to #

  ## Type Of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor/cleanup
  - [x] Documentation update
  - [x] Tests only

  ## What Changed

  - Default config path now resolves to `~/.config/sm-logtool/config.yaml`
    (or `SM_LOGTOOL_CONFIG` when set).
  - On first run without `--config`, missing config file is auto-created with:
    - `logs_dir: /var/lib/smartermail/Logs`
    - `staging_dir: /var/tmp/sm-logtool/logs`
    - `default_kind: smtp`
  - Added tests for auto-created default config and env-driven config path.
  - Updated README config resolution/defaults.
  - Updated sample `config.yaml` staging path.
  - Bumped package version to `0.9.1`.

  ## Testing

  ```bash
  .venv/bin/python -m pytest -q
  # 52 passed

  .venv/bin/python -m unittest discover test
  # Ran 1 test ... OK

  ## UI Changes (if applicable)

  - [x] No UI changes
  - [ ] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not main).
  - [x] I added or updated tests for behavior changes.
  - [x] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.

