### PR TITLE
Add top-level --version CLI flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ Treat SmarterMail logs as sensitive—redact personal data before sharing. Alway
 - [ ] Add support for additional compressed log formats (for example `.gz`).
 - [ ] Improve large-log search performance/responsiveness (progress feedback,
   background work, reduced memory footprint).
-- [ ] Add `--version` CLI flag to print installed package version.
+- [x] Add `--version` CLI flag to print installed package version.
 - [ ] Add export controls (matched lines vs full conversations; optional
   structured output).
 - [x] Plan packaging/distribution (standalone binaries, pipx, release workflow).

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Top-level help:
 
 ```bash
 sm-logtool --help
+sm-logtool --version
 ```
 
 ### Launch the TUI

--- a/sm_logtool/cli.py
+++ b/sm_logtool/cli.py
@@ -6,6 +6,7 @@ Provides a TUI browser (`browse`) and a search workflow (`search`).
 from __future__ import annotations
 
 import argparse
+from importlib import metadata
 import textwrap
 from pathlib import Path
 import sys
@@ -59,6 +60,11 @@ def build_parser() -> argparse.ArgumentParser:
             "Path to a YAML config file. Defaults to $SM_LOGTOOL_CONFIG or "
             "~/.config/sm-logtool/config.yaml."
         ),
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {_package_version()}",
     )
 
     subparsers = parser.add_subparsers(dest="command")
@@ -178,6 +184,13 @@ def main(argv: list[str] | None = None) -> int:
     handler = getattr(args, "handler", _run_browse)
 
     return handler(args)
+
+
+def _package_version() -> str:
+    try:
+        return metadata.version("sm-logtool")
+    except metadata.PackageNotFoundError:
+        return "unknown"
 
 
 def _run_browse(args: argparse.Namespace) -> int:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -446,3 +446,17 @@ def test_run_search_list_kinds_does_not_require_dirs(capsys):
     captured = capsys.readouterr()
     assert "Supported log kinds:" in captured.out
     assert "smtp" in captured.out
+
+
+def test_main_version_flag_prints_version_and_exits_zero(
+    capsys,
+    monkeypatch,
+):
+    monkeypatch.setattr(cli, "_package_version", lambda: "9.9.9")
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["--version"])
+
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "sm-logtool 9.9.9"


### PR DESCRIPTION
# Summary

  Adds a top-level `--version` CLI flag so users can print the installed package
  version and exit successfully.

  ## Related Issues

  - Closes #22
  - Related to #

  ## Type Of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor/cleanup
  - [x] Documentation update
  - [x] Tests only

  ## What Changed

  - Added `--version` support at the top-level parser in `sm_logtool/cli.py`.
  - Added package version resolution via `importlib.metadata` with fallback to
    `unknown` if package metadata is unavailable.
  - Added CLI test validating `sm-logtool --version` output and exit code.
  - Updated README top-level usage examples to include `sm-logtool --version`.
  - Marked the corresponding `AGENTS.md` Upcoming Work item as completed.

  ## Testing

  List the commands you ran and their results.

  ```bash
  .venv/bin/python -m pytest -q
  # passed

  .venv/bin/python -m unittest discover test
  # passed

  ## UI Changes (if applicable)

  - [x] No UI changes
  - [ ] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not main).
  - [x] I added or updated tests for behavior changes.
  - [x] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.
