### PR TITLE
Sync roadmap docs with not-planned compression decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,8 @@ Treat SmarterMail logs as sensitive—redact personal data before sharing. Alway
 - [x] Bring CLI search and output behavior to parity with the TUI across supported log kinds.
 - [ ] Add regex search mode with explicit CLI/TUI controls.
 - [ ] Add fuzzy search mode with configurable matching thresholds.
-- [ ] Add support for additional compressed log formats (for example `.gz`).
+- [x] Add support for additional compressed log formats (for example `.gz`)
+  [Issue #20 closed as not planned; reopen if needed].
 - [ ] Improve large-log search performance/responsiveness (progress feedback,
   background work, reduced memory footprint).
 - [x] Add `--version` CLI flag to print installed package version.

--- a/docs/SEARCH_NOTES.md
+++ b/docs/SEARCH_NOTES.md
@@ -56,14 +56,15 @@ Search handlers currently exist for:
 
 ## Roadmap Items
 
-- Bring CLI search/output behavior closer to TUI behavior where practical.
-- Add regex search mode with explicit mode flags and clear UX.
-- Add fuzzy/approximate search mode with configurable thresholds.
-- Add support for additional compressed formats (for example `.gz`).
-- Improve large-log performance and responsiveness (progress feedback,
+- [x] Bring CLI search/output behavior closer to TUI behavior where practical.
+- [ ] Add regex search mode with explicit mode flags and clear UX.
+- [ ] Add fuzzy/approximate search mode with configurable thresholds.
+- [x] Add support for additional compressed formats (for example `.gz`)
+  [Issue #20 closed as not planned; reopen if needed].
+- [ ] Improve large-log performance and responsiveness (progress feedback,
   background work, reduced memory footprint).
-- Add export controls (matched lines vs full conversations, optional
-  structured output).
+- [x] Add export controls (matched lines vs full conversations, optional
+  structured output) [Issue #23 closed as not planned; reopen if needed].
 
 ## Notes
 


### PR DESCRIPTION
 # Summary

  Aligns project roadmap docs with current issue decisions by marking compressed
  format expansion as not planned and syncing related roadmap status entries.

  ## Related Issues

  - Closes #
  - Related to #20
  - Related to #23

  ## Type Of Change

  - [ ] Bug fix
  - [ ] New feature
  - [x] Refactor/cleanup
  - [x] Documentation update
  - [ ] Tests only

  ## What Changed

  - Updated `AGENTS.md` `Upcoming Work`:
    - Marked additional compressed format support item as completed with note:
      `Issue #20 closed as not planned; reopen if needed`.
  - Updated `docs/SEARCH_NOTES.md` `Roadmap Items` to stay in sync with
    `AGENTS.md`:
    - CLI parity item marked complete.
    - Compressed formats item marked not planned with `#20` note.
    - Export controls item marked not planned with `#23` note.
  - Issue tracking updates:
    - Closed issue `#20` as `not planned`.
    - Added `wontfix` label and rationale comment on `#20`.

  ## Testing

  No runtime code changes; documentation/issue-tracking updates only.

  ## UI Changes (if applicable)

  - [x] No UI changes
  - [ ] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not `main`).
  - [ ] I added or updated tests for behavior changes.
  - [x] I updated docs (`README.md`, `CONTRIBUTING.md`, or `docs/`) as needed.
  - [x] I used present tense in user-facing docs.
