### PR TITLE
Track wildcard mode and search mode switching roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,9 @@ Treat SmarterMail logs as sensitive—redact personal data before sharing. Alway
 - [x] Add syntax highlighting for supported log kinds in the CLI view.
 - [x] Bring CLI search and output behavior to parity with the TUI across supported log kinds.
 - [ ] Add regex search mode with explicit CLI/TUI controls.
+- [ ] Add wildcard search mode with `*` and `?` support in CLI/TUI.
 - [ ] Add fuzzy search mode with configurable matching thresholds.
+- [ ] Add explicit search mode switching plus clear CLI/TUI help text.
 - [x] Add support for additional compressed log formats (for example `.gz`)
   [Issue #20 closed as not planned; reopen if needed].
 - [ ] Improve large-log search performance/responsiveness (progress feedback,

--- a/docs/SEARCH_NOTES.md
+++ b/docs/SEARCH_NOTES.md
@@ -58,7 +58,9 @@ Search handlers currently exist for:
 
 - [x] Bring CLI search/output behavior closer to TUI behavior where practical.
 - [ ] Add regex search mode with explicit mode flags and clear UX.
+- [ ] Add wildcard search mode with `*` and `?` support in CLI/TUI.
 - [ ] Add fuzzy/approximate search mode with configurable thresholds.
+- [ ] Add explicit search mode switching plus clear CLI/TUI help text.
 - [x] Add support for additional compressed formats (for example `.gz`)
   [Issue #20 closed as not planned; reopen if needed].
 - [ ] Improve large-log performance and responsiveness (progress feedback,


### PR DESCRIPTION
 # Summary

  Adds roadmap coverage for wildcard search and explicit search-mode switching/help,
  and keeps project planning docs synchronized.

  ## Related Issues

  - Closes #
  - Related to #27
  - Related to #28

  ## Type Of Change

  - [ ] Bug fix
  - [ ] New feature
  - [x] Refactor/cleanup
  - [x] Documentation update
  - [ ] Tests only

  ## What Changed

  - Updated `AGENTS.md` `Upcoming Work` with two new items:
    - Add wildcard search mode with `*` and `?` support in CLI/TUI.
    - Add explicit search mode switching plus clear CLI/TUI help text.
  - Updated `docs/SEARCH_NOTES.md` `Roadmap Items` with matching entries so both
    planning docs stay in sync.
  - Created two new enhancement issues to track implementation:
    - #27 Add wildcard search mode with `*` and `?` support
    - #28 Add explicit search mode switching and mode-specific help in CLI/TUI

  ## Testing

  No runtime code changes; documentation/roadmap update only.

  ## UI Changes (if applicable)

  - [x] No UI changes
  - [ ] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not `main`).
  - [ ] I added or updated tests for behavior changes.
  - [x] I updated docs (`README.md`, `CONTRIBUTING.md`, or `docs/`) as needed.
  - [x] I used present tense in user-facing docs.
