### PR TITLE
Add fuzzy search mode with configurable thresholds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Treat SmarterMail logs as sensitive—redact personal data before sharing. Alway
 - [x] Bring CLI search and output behavior to parity with the TUI across supported log kinds.
 - [x] Add regex search mode with explicit CLI/TUI controls.
 - [x] Add wildcard search mode with `*` and `?` support in CLI/TUI.
-- [ ] Add fuzzy search mode with configurable matching thresholds.
+- [x] Add fuzzy search mode with configurable matching thresholds.
 - [x] Add explicit search mode switching plus clear CLI/TUI help text.
 - [x] Add support for additional compressed log formats (for example `.gz`)
   [Issue #20 closed as not planned; reopen if needed].

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Wizard flow:
 1. Choose log kind.
 2. Select one or more log dates.
 3. Enter search term and choose search mode
-   (`Literal`/`Wildcard`/`Regex`).
+   (`Literal`/`Wildcard`/`Regex`/`Fuzzy`).
 4. Review results, copy selection/all, and optionally run sub-search.
 
 Core actions are always visible in the top action strip:
@@ -102,6 +102,8 @@ Search-step footer shortcuts:
 - `Ctrl+F` focus search input
 - `Ctrl+Left` previous search mode
 - `Ctrl+Right` next search mode
+- `Ctrl+Up` increase fuzzy threshold (fuzzy mode only)
+- `Ctrl+Down` decrease fuzzy threshold (fuzzy mode only)
 
 Date selection shortcuts:
 
@@ -129,6 +131,10 @@ sm-logtool search --mode wildcard "Login failed: User * not found"
 
 # Regex mode: Python regular expression
 sm-logtool search --mode regex "Login failed: User \\[(sales|billing)\\]"
+
+# Fuzzy mode: approximate matching with configurable threshold
+sm-logtool search --mode fuzzy --fuzzy-threshold 0.72 \
+  "Authentcation faild for user [sales]"
 ```
 
 Target resolution:
@@ -148,7 +154,9 @@ Search options:
 - `--log-file`: explicit file to search. Repeat to search multiple files.
 - `--list`: list available logs for the selected kind and exit.
 - `--list-kinds`: list supported kinds and exit.
-- `--mode`: search mode (`literal`, `wildcard`, or `regex`).
+- `--mode`: search mode (`literal`, `wildcard`, `regex`, or `fuzzy`).
+- `--fuzzy-threshold`: similarity threshold for `--mode fuzzy` from `0.00` to
+  `1.00` (default `0.75`).
 - `--case-sensitive`: disable default case-insensitive matching.
 
 Search mode behavior:
@@ -156,6 +164,7 @@ Search mode behavior:
 - `literal`: exact substring matching (default).
 - `wildcard`: `*` matches any sequence and `?` matches one character.
 - `regex`: Python `re` syntax (PCRE-like, but not full PCRE).
+- `fuzzy`: approximate line matching using a similarity threshold.
 
 Regex checker note:
 

--- a/docs/SEARCH_NOTES.md
+++ b/docs/SEARCH_NOTES.md
@@ -10,6 +10,7 @@ This file tracks current search behavior and near-term design goals.
   - `literal`: plain substring matching (default).
   - `wildcard`: supports `*` (any sequence) and `?` (single character).
   - `regex`: Python `re` syntax (PCRE-like, not full PCRE).
+  - `fuzzy`: approximate matching using a configurable similarity threshold.
 - Matching is case-insensitive by default.
 - CLI supports `--case-sensitive` for exact-case matching.
 
@@ -48,7 +49,8 @@ Search handlers currently exist for:
 - Wizard flow: log kind -> date selection -> search -> results.
 - Date selection supports keyboard and mouse toggling.
 - Search step includes explicit mode switching
-  (`Literal`/`Wildcard`/`Regex`).
+  (`Literal`/`Wildcard`/`Regex`/`Fuzzy`).
+- Fuzzy mode threshold can be adjusted in TUI with `Ctrl+Up`/`Ctrl+Down`.
 - Sub-search chains are supported from results.
 - Results pane has syntax highlighting across supported log kinds.
 - Copy selection and copy-all actions are available from results.
@@ -57,7 +59,8 @@ Search handlers currently exist for:
 
 - `search` and `browse` subcommands exist.
 - `search` supports explicit `--mode` selection
-  (`literal`/`wildcard`/`regex`).
+  (`literal`/`wildcard`/`regex`/`fuzzy`).
+- `search` supports `--fuzzy-threshold` to tune fuzzy matching sensitivity.
 - CLI search output uses the same syntax highlighting tokens as the TUI.
 - CLI does not provide interactive TUI workflows like sub-search chaining.
 
@@ -66,7 +69,7 @@ Search handlers currently exist for:
 - [x] Bring CLI search/output behavior closer to TUI behavior where practical.
 - [x] Add regex search mode with explicit mode flags and clear UX.
 - [x] Add wildcard search mode with `*` and `?` support in CLI/TUI.
-- [ ] Add fuzzy/approximate search mode with configurable thresholds.
+- [x] Add fuzzy/approximate search mode with configurable thresholds.
 - [x] Add explicit search mode switching plus clear CLI/TUI help text.
 - [x] Add support for additional compressed formats (for example `.gz`)
   [Issue #20 closed as not planned; reopen if needed].

--- a/sm_logtool/search_modes.py
+++ b/sm_logtool/search_modes.py
@@ -7,23 +7,31 @@ import re
 MODE_LITERAL = "literal"
 MODE_WILDCARD = "wildcard"
 MODE_REGEX = "regex"
+MODE_FUZZY = "fuzzy"
+
+DEFAULT_FUZZY_THRESHOLD = 0.75
+MIN_FUZZY_THRESHOLD = 0.0
+MAX_FUZZY_THRESHOLD = 1.0
 
 SUPPORTED_SEARCH_MODES = (
     MODE_LITERAL,
     MODE_WILDCARD,
     MODE_REGEX,
+    MODE_FUZZY,
 )
 
 SEARCH_MODE_LABELS = {
     MODE_LITERAL: "Literal",
     MODE_WILDCARD: "Wildcard",
     MODE_REGEX: "Regex",
+    MODE_FUZZY: "Fuzzy",
 }
 
 SEARCH_MODE_DESCRIPTIONS = {
     MODE_LITERAL: "Exact substring match.",
     MODE_WILDCARD: "'*' matches many chars, '?' matches one char.",
     MODE_REGEX: "Python re syntax (PCRE-like, not full PCRE).",
+    MODE_FUZZY: "Approximate line match using similarity threshold.",
 }
 
 
@@ -37,6 +45,23 @@ def normalize_search_mode(value: str | None) -> str:
     choices = ", ".join(SUPPORTED_SEARCH_MODES)
     raise ValueError(
         f"Unsupported search mode: {value!r}. Choose one of: {choices}."
+    )
+
+
+def normalize_fuzzy_threshold(value: float | None) -> float:
+    """Validate and normalize fuzzy threshold."""
+
+    if value is None:
+        return DEFAULT_FUZZY_THRESHOLD
+
+    threshold = float(value)
+    if MIN_FUZZY_THRESHOLD <= threshold <= MAX_FUZZY_THRESHOLD:
+        return threshold
+
+    raise ValueError(
+        "Invalid fuzzy threshold: "
+        f"{value!r}. Choose a value between "
+        f"{MIN_FUZZY_THRESHOLD:.2f} and {MAX_FUZZY_THRESHOLD:.2f}."
     )
 
 


### PR DESCRIPTION
  # Summary

  Add fuzzy search mode with configurable thresholds across CLI and TUI, including shared mode definitions, engine support, threshold controls, tests, and documentation updates.

  ## Related Issues

  - Closes #19
  - Related to #21

  ## Type Of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor/cleanup
  - [x] Documentation update
  - [ ] Tests only

  ## What Changed

  - Added fuzzy mode and threshold constants/validation in sm_logtool/search_modes.py.
  - Added fuzzy matching support in search engine (sm_logtool/search.py) with:
  - configurable fuzzy_threshold
  - approximate line matching based on similarity
  - threshold validation errors surfaced as ValueError
  - Updated CLI (sm_logtool/cli.py):
  - --mode fuzzy
  - new --fuzzy-threshold option
  - help text and validation/error handling
  - Updated TUI (sm_logtool/ui/app.py):
  - mode cycle now includes Fuzzy
  - mode status includes current threshold
  - Ctrl+Up/Ctrl+Down adjust fuzzy threshold in search step
  - Added/updated tests:
  - test/test_search.py
  - test/test_cli.py
  - test/test_ui_bindings.py
  - Updated docs:
  - README.md
  - docs/SEARCH_NOTES.md
  - AGENTS.md

  ## Testing

  List the commands you ran and their results.

  pytest -q
  python -m unittest discover test

  Result: both commands passed.

  Manual validation:

  - TUI fuzzy mode tested for both match and non-match behavior using subsearch-limited scope.
  - CLI fuzzy mode validated on smaller scopes; full daily logs are currently slow (performance follow-up tracked in #21).

  ## UI Changes (if applicable)

  - [ ] No UI changes
  - [x] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not main).
  - [x] I added or updated tests for behavior changes.
  - [x] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.
