### PR TITLE
Docs/issue 21 performance notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,3 +126,35 @@ Treat SmarterMail logs as sensitive—redact personal data before sharing. Alway
   - Add profiling notes and before/after measurements in the PR.
   - Keep CLI/TUI behavior parity and preserve existing test expectations.
   - Add focused tests for cancellation/progress and large-file regressions.
+- Proposed phased execution plan:
+  - Phase 0: Measurement harness and reproducible baseline.
+  - Deliverables:
+    - Add repeatable benchmark script(s) for key log kinds/modes.
+    - Record local vs server timings, RSS, and time-to-first-result.
+    - Add an issue comment table with baseline numbers before code changes.
+  - Exit criteria:
+    - We can run one command to reproduce baseline metrics on demand.
+  - Phase 1: Low-risk hot path wins (no behavior changes).
+  - Deliverables:
+    - Add a fast literal matcher path that avoids regex when mode=literal.
+    - Reduce repeated parsing in rendering/formatting where practical.
+    - Keep today's-log staging refresh behavior unchanged for correctness.
+  - Exit criteria:
+    - Literal/wildcard/regex searches show measurable server-side speedup.
+    - Existing CLI/TUI output and tests remain unchanged.
+  - Phase 2: Responsiveness and coarse-grained parallelism.
+  - Deliverables:
+    - Move TUI search work off the event loop with progress/cancel support.
+    - Add process-based parallel search across selected files/dates.
+    - Preserve deterministic output ordering in merged results.
+  - Exit criteria:
+    - TUI stays interactive during long searches.
+    - Multi-target searches are materially faster on high-core servers.
+  - Phase 3: Deep optimization for very large single files.
+  - Deliverables:
+    - Replace or redesign fuzzy matching to avoid heavy difflib costs.
+    - Evaluate safe chunk/merge rules for within-file parallel processing.
+    - Add guardrails for memory use on very large result sets.
+  - Exit criteria:
+    - Fuzzy mode no longer dominates runtime at large scales.
+    - Single-file large-log searches improve without grouping regressions.


### PR DESCRIPTION

  # Summary

  Add deferred planning notes for Issue #21 in `AGENTS.md`, including:
  - performance baseline expectations,
  - concurrency strategy notes (threads vs processes),
  - SmarterMail staging correctness caveat for today's logs,
  - phased execution plan (Phase 0-3) with deliverables and exit criteria.

  ## Related Issues

  - Closes # (none)
  - Related to #21

  ## Type Of Change

  - [ ] Bug fix
  - [ ] New feature
  - [ ] Refactor/cleanup
  - [x] Documentation update
  - [ ] Tests only

  ## What Changed

  - Added "Issue #21 Planning Notes (Deferred)" section in `AGENTS.md`.
  - Documented concurrency guidance:
    - threads for responsiveness,
    - process-based parallelism for CPU throughput,
    - chunk/merge caution for conversation continuity.
  - Documented required staging behavior:
    - non-today logs can be reused,
    - today's active log must be recopied before search.
  - Added phased implementation plan:
    - Phase 0 baseline harness/metrics,
    - Phase 1 low-risk hot-path wins,
    - Phase 2 TUI responsiveness + per-target process parallelism,
    - Phase 3 deep optimization for fuzzy/large single-file searches.
  - Added corresponding issue note in GitHub:
    - https://github.com/T313C0mun1s7/sm-logtool/issues/21#issuecomment-3899795143

  ## Testing

  Docs-only change; no code-path changes and no tests run.

  ### Not run (documentation-only PR)
  pytest -q
  python -m unittest discover test

  ## UI Changes (if applicable)

  - [x] No UI changes
  - [ ] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not main).
  - [ ] I added or updated tests for behavior changes. (Not applicable: docs-only)
  - [x] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.