### PR TITLE
Persist TUI theme in config and apply on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Configuration is YAML with these keys:
 - `logs_dir`: source SmarterMail logs directory.
 - `staging_dir`: working directory used for copied/unzipped logs.
 - `default_kind`: default log kind (for example `smtp`).
+- `theme`: Textual UI theme name (for example `textual-dark`).
 
 Example:
 
@@ -53,6 +54,7 @@ Example:
 logs_dir: /var/lib/smartermail/Logs
 staging_dir: /var/tmp/sm-logtool/logs
 default_kind: smtp
+theme: textual-dark
 ```
 
 If `staging_dir` does not exist yet, the app creates it automatically.

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,4 @@
 logs_dir: /var/lib/smartermail/Logs
 staging_dir: /var/tmp/sm-logtool/logs
 default_kind: smtp
+theme: textual-dark

--- a/sm_logtool/cli.py
+++ b/sm_logtool/cli.py
@@ -247,6 +247,8 @@ def _run_browse(args: argparse.Namespace) -> int:
         logs_dir,
         staging_dir=staging_dir,
         default_kind=config.default_kind,
+        config_path=config.path,
+        theme=config.theme,
     )
 
 


### PR DESCRIPTION
 # Summary

  Persist TUI theme selection across sessions by adding theme support in
  config.yaml, applying it on startup, and saving changes when users switch
  themes via the Menu/Command Palette.

  ## Related Issues

  - Closes #34
  - Related to #34

  ## Type Of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor/cleanup
  - [x] Documentation update
  - [ ] Tests only

  ## What Changed

  - Added theme to config model/loading/default creation in sm_logtool/config.py.
  - Added save_theme(...) helper to persist theme updates back to config.
  - Passed config path + configured theme from CLI browse flow into TUI (sm_logtool/cli.py).
  - Updated LogBrowser to:
      - apply configured theme on startup when valid,
      - gracefully ignore invalid configured themes (no crash),
      - persist theme changes when App.theme changes at runtime.
  - Added tests for:
      - config read/write and theme validation (test/test_config.py),
      - startup apply behavior and runtime persistence (test/test_ui_bindings.py).
  - Updated docs/sample config with the new theme key (README.md, config.yaml).

  ## Testing

  List the commands you ran and their results.

  `pytest -q`
  Result: pass

  `python -m unittest discover test`
  Result: pass

  ### UI Changes (if applicable)

  - [ ] No UI changes
  - [x] UI changed (theme persistence behavior)

  ### Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ### Checklist

  - [x] I used a feature branch (not main).
  - [x] I added or updated tests for behavior changes.
  - [x] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.