### PR TITLE
Feature/issue 40 button truncation

### DIFF
--- a/sm_logtool/ui/app.py
+++ b/sm_logtool/ui/app.py
@@ -1386,6 +1386,7 @@ class LogBrowser(App):
     .button-row {
         width: 1fr;
         height: auto;
+        margin-top: 1;
     }
 
     .button-row Button {
@@ -1484,6 +1485,14 @@ class LogBrowser(App):
 
     .mode-description {
         width: 1fr;
+    }
+
+    .search-term-input {
+        margin-bottom: 1;
+    }
+
+    .selection-list {
+        margin-bottom: 1;
     }
     """
 
@@ -1595,9 +1604,20 @@ class LogBrowser(App):
         self.wizard.mount(
             Static("Step 1: Choose a log type", classes="instruction")
         )
+        next_button = Button(
+            "Next",
+            id="next-kind",
+            classes="action-button",
+        )
+        quit_button = Button(
+            "Quit",
+            id="quit-kind",
+            classes="action-button",
+        )
+        self._set_uniform_button_group_widths([next_button, quit_button])
         button_row = Horizontal(
-            Button("Next", id="next-kind"),
-            Button("Quit", id="quit-kind"),
+            next_button,
+            quit_button,
             classes="button-row",
         )
 
@@ -1605,6 +1625,7 @@ class LogBrowser(App):
             self.kind_list = KindListView(
                 ListItem(Static("No logs discovered"))
             )
+            self.kind_list.add_class("selection-list")
             self.current_kind = None
             self.wizard.mount(self.kind_list)
             self.kind_list.focus()
@@ -1623,6 +1644,7 @@ class LogBrowser(App):
                 *items,
                 initial_index=initial_index,
             )
+            self.kind_list.add_class("selection-list")
             self.current_kind = preferred
             self.wizard.mount(self.kind_list)
             if preferred:
@@ -1649,11 +1671,23 @@ class LogBrowser(App):
         self.wizard.mount(instructions)
 
         self.date_list = DateListView()
+        self.date_list.add_class("selection-list")
         self.wizard.mount(self.date_list)
 
+        back_button = Button(
+            "Back",
+            id="back-date",
+            classes="action-button",
+        )
+        next_button = Button(
+            "Next",
+            id="next-date",
+            classes="action-button",
+        )
+        self._set_uniform_button_group_widths([back_button, next_button])
         button_row = Horizontal(
-            Button("Back", id="back-date"),
-            Button("Next", id="next-date"),
+            back_button,
+            next_button,
             classes="button-row",
         )
         self.wizard.mount(button_row)
@@ -1685,6 +1719,7 @@ class LogBrowser(App):
             placeholder="Enter search term",
             id="search-term",
         )
+        self.search_input.add_class("search-term-input")
         self.wizard.mount(self.search_input)
         self.search_mode_status = Static(
             self._search_mode_status_text(),


### PR DESCRIPTION
  # Summary

  This PR fixes TUI action-button truncation and standardizes button layout across all wizard steps. It makes action buttons
  compact, applies uniform per-group button widths, and adds explicit vertical spacing so the UI remains readable and
  consistent in narrow terminals.

  ## Related Issues

  - Closes #40
  - Related to #21

  ## Type Of Change

  - [x] Bug fix
  - [ ] New feature
  - [x] Refactor/cleanup
  - [ ] Documentation update
  - [ ] Tests only

  ## What Changed

  - Fixed button-row layout so left/right groups keep natural width and the spacer is the only flexible element.
  - Standardized compact action-button styling across Kind/Date/Search/Results steps.
  - Added per-group button width normalization:
    - each button width = longest label in the group + 2.
  - Applied consistent spacing rules:
    - blank line between list/results content and action rows.
    - on Search: blank line between input and status, and between status and action row.
  - Added/updated UI regression tests to verify:
    - explicit left/right groups in Search/Results rows
    - compact action-button usage on Kind/Date rows
    - uniform per-group button widths.

  ## Testing

  List the commands you ran and their results.

  ```bash
  python -m py_compile sm_logtool/ui/app.py test/test_ui_bindings.py
  pytest -q test/test_ui_bindings.py
  pytest -q
  python -m unittest discover test
```

  - All commands passed.

  ## UI Changes (if applicable)

  - [ ] No UI changes
  - [x] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not main).
  - [x] I added or updated tests for behavior changes.
  - [x] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.