### PR TITLE
Make release default guard independent of PyYAML

### DIFF
--- a/scripts/check_release_defaults.py
+++ b/scripts/check_release_defaults.py
@@ -1,39 +1,80 @@
 #!/usr/bin/env python3
-"""Release guard checks for repository defaults."""
+"""Release guard checks for repository defaults.
+
+This script intentionally uses only Python's standard library so it can run
+early in CI before project dependencies are installed.
+"""
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 import sys
-
-import yaml
-
-from sm_logtool import config
 
 
 EXPECTED_THEME = "Cyberdark"
 
 
-def _load_repo_config(path: Path) -> dict[str, object]:
+def _load_default_theme_constant(path: Path) -> str:
+    """Read ``DEFAULT_THEME`` from ``sm_logtool/config.py``."""
+
     if not path.exists():
         raise RuntimeError(f"Missing required file: {path}")
-    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise RuntimeError(f"Expected mapping in {path}, got {type(payload).__name__}")
-    return payload
+    source = path.read_text(encoding="utf-8")
+    module = ast.parse(source, filename=str(path))
+    for node in module.body:
+        if isinstance(node, ast.Assign):
+            targets = [t for t in node.targets if isinstance(t, ast.Name)]
+            for target in targets:
+                if target.id != "DEFAULT_THEME":
+                    continue
+                if (
+                    isinstance(node.value, ast.Constant)
+                    and isinstance(node.value.value, str)
+                ):
+                    return node.value.value
+                raise RuntimeError(
+                    "DEFAULT_THEME must be assigned to a string literal."
+                )
+    raise RuntimeError("DEFAULT_THEME not found in sm_logtool/config.py.")
+
+
+def _load_top_level_scalar(path: Path, key: str) -> str:
+    """Read a simple top-level ``key: value`` scalar from YAML text."""
+
+    if not path.exists():
+        raise RuntimeError(f"Missing required file: {path}")
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        left, right = line.split(":", 1)
+        if left.strip() != key:
+            continue
+        value = right.strip()
+        if (
+            len(value) >= 2
+            and value[0] == value[-1]
+            and value[0] in {'"', "'"}
+        ):
+            value = value[1:-1]
+        return value
+    raise RuntimeError(f"Key {key!r} not found in {path}.")
 
 
 def main() -> int:
     failures: list[str] = []
 
-    if config.DEFAULT_THEME != EXPECTED_THEME:
+    module_theme = _load_default_theme_constant(Path("sm_logtool/config.py"))
+    if module_theme != EXPECTED_THEME:
         failures.append(
-            "sm_logtool.config.DEFAULT_THEME "
-            f"is {config.DEFAULT_THEME!r}, expected {EXPECTED_THEME!r}."
+            "sm_logtool/config.py DEFAULT_THEME "
+            f"is {module_theme!r}, expected {EXPECTED_THEME!r}."
         )
 
-    repo_cfg = _load_repo_config(Path("config.yaml"))
-    repo_theme = repo_cfg.get("theme")
+    repo_theme = _load_top_level_scalar(Path("config.yaml"), "theme")
     if repo_theme != EXPECTED_THEME:
         failures.append(
             f"config.yaml theme is {repo_theme!r}, expected {EXPECTED_THEME!r}."
@@ -47,7 +88,7 @@ def main() -> int:
 
     print(
         "Release default checks passed: "
-        f"DEFAULT_THEME={config.DEFAULT_THEME!r}, config.yaml theme={repo_theme!r}."
+        f"DEFAULT_THEME={module_theme!r}, config.yaml theme={repo_theme!r}."
     )
     return 0
 


### PR DESCRIPTION

 # Summary

  Fix the publish pipeline failure by making the release default-theme guard
  script independent of optional Python dependencies.

  ## Related Issues

  - Closes #N/A
  - Related to #44
  - Related to 0.9.3 publish workflow

  ## Type Of Change

  - [x] Bug fix
  - [ ] New feature
  - [x] Refactor/cleanup
  - [ ] Documentation update
  - [ ] Tests only

  ## What Changed

  - Reworked `scripts/check_release_defaults.py` to use only Python standard
    library modules.
  - Removed dependency on:
    - `PyYAML` (`import yaml`)
    - `sm_logtool.config` import path (which indirectly required `PyYAML`)
  - New script behavior:
    - Reads `DEFAULT_THEME` from `sm_logtool/config.py` via AST parsing.
    - Reads `theme` from repository `config.yaml` using simple top-level scalar
      parsing.
    - Fails with clear messages if either value is not `Cyberdark`.
  - This allows publish workflow step
    `python scripts/check_release_defaults.py` to run successfully before project
    dependencies are installed.

  ## Testing

  List the commands you ran and their results.

  ```bash
  python scripts/check_release_defaults.py
  pytest -q
  python -m unittest discover test
```

  All passed.

  ## UI Changes (if applicable)

  - [x] No UI changes
  - [ ] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not main).
  - [ ] I added or updated tests for behavior changes.
  - [ ] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.