### PR TITLE
Create theme directories on first-run UI launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Theme file locations (per-user):
   `~/.config/sm-logtool/theme-sources`
 - Converted themes saved by Theme Studio:
   `~/.config/sm-logtool/themes`
+- Both directories are created automatically on first run of
+  `sm-logtool browse` or `sm-logtool themes`.
 
 These locations are user-home paths, so imported/converted themes are local
 user settings, not repository files.

--- a/docs/SEARCH_NOTES.md
+++ b/docs/SEARCH_NOTES.md
@@ -81,6 +81,8 @@ Search handlers currently exist for:
   `~/.config/sm-logtool/themes` (per-user).
 - Theme Studio imports source files from
   `~/.config/sm-logtool/theme-sources` by default (per-user).
+- These directories are created automatically on first run of
+  `sm-logtool browse` or `sm-logtool themes`.
 - Theme Studio supports live semantic remapping against preview elements.
 - Saved themes preserve both app chrome and syntax palette behavior.
 - Selection-state colors are forced distinct before save so date-selection

--- a/sm_logtool/cli.py
+++ b/sm_logtool/cli.py
@@ -37,8 +37,7 @@ from .search_modes import (
 )
 from .search import get_search_function
 from .staging import stage_log
-from .ui.theme_importer import default_theme_source_dir
-from .ui.theme_importer import default_theme_store_dir
+from .ui.theme_importer import ensure_default_theme_dirs
 from .ui.theme_importer import SUPPORTED_THEME_MAPPING_PROFILES
 
 
@@ -283,6 +282,7 @@ def _run_browse(args: argparse.Namespace) -> int:
             "is installed.\n"
             f"Details: {exc}"
         ) from exc
+    theme_store_dir, _ = ensure_default_theme_dirs(config.path)
 
     return run_tui(
         logs_dir,
@@ -290,7 +290,7 @@ def _run_browse(args: argparse.Namespace) -> int:
         default_kind=config.default_kind,
         config_path=config.path,
         theme=config.theme,
-        theme_store_dir=default_theme_store_dir(),
+        theme_store_dir=theme_store_dir,
         theme_import_paths=config.theme_import_paths,
         theme_mapping_profile=config.theme_mapping_profile,
         theme_quantize_ansi256=config.theme_quantize_ansi256,
@@ -301,11 +301,14 @@ def _run_browse(args: argparse.Namespace) -> int:
 
 def _run_themes(args: argparse.Namespace) -> int:
     config: AppConfig = getattr(args, CONFIG_ATTR)
+    default_store_dir, default_source_dir = ensure_default_theme_dirs(
+        config.path
+    )
     source_paths = tuple(
         args.source
-        or (default_theme_source_dir(),)
+        or (default_source_dir,)
     )
-    store_dir = args.store_dir or default_theme_store_dir()
+    store_dir = args.store_dir or default_store_dir
 
     try:
         from .ui.theme_studio import run as run_studio  # type: ignore

--- a/sm_logtool/ui/theme_importer.py
+++ b/sm_logtool/ui/theme_importer.py
@@ -1097,6 +1097,18 @@ def default_theme_source_dir(config_path: Path | None = None) -> Path:
     return Path.home() / ".config" / "sm-logtool" / "theme-sources"
 
 
+def ensure_default_theme_dirs(
+    config_path: Path | None = None,
+) -> tuple[Path, Path]:
+    """Ensure default per-user theme directories exist and return them."""
+
+    store_dir = default_theme_store_dir(config_path).expanduser()
+    source_dir = default_theme_source_dir(config_path).expanduser()
+    for directory in (store_dir, source_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+    return store_dir, source_dir
+
+
 def save_converted_theme(
     *,
     theme: Theme,

--- a/test/test_theme_importer.py
+++ b/test/test_theme_importer.py
@@ -5,6 +5,7 @@ import plistlib
 
 from rich.color import Color
 from sm_logtool.ui.theme_importer import default_theme_store_dir
+from sm_logtool.ui.theme_importer import ensure_default_theme_dirs
 from sm_logtool.ui.theme_importer import map_terminal_palette
 from sm_logtool.ui.theme_importer import TerminalPalette
 from sm_logtool.ui.theme_importer import load_saved_themes
@@ -144,6 +145,33 @@ def test_default_theme_store_dir_uses_config_parent(tmp_path: Path) -> None:
     config_path = tmp_path / "config" / "custom.yaml"
     expected = Path.home() / ".config" / "sm-logtool" / "themes"
     assert default_theme_store_dir(config_path) == expected
+
+
+def test_ensure_default_theme_dirs_creates_missing_paths(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "sm_logtool.ui.theme_importer.Path.home",
+        lambda: tmp_path,
+    )
+
+    expected_store = (
+        tmp_path / ".config" / "sm-logtool" / "themes"
+    )
+    expected_source = (
+        tmp_path / ".config" / "sm-logtool" / "theme-sources"
+    )
+
+    store_dir, source_dir = ensure_default_theme_dirs()
+    assert store_dir == expected_store
+    assert source_dir == expected_source
+    assert store_dir.is_dir()
+    assert source_dir.is_dir()
+
+    second_store, second_source = ensure_default_theme_dirs()
+    assert second_store == store_dir
+    assert second_source == source_dir
 
 
 def test_save_converted_theme_overwrites_by_name(tmp_path: Path) -> None:


### PR DESCRIPTION
 # Summary

  Ensure per-user theme directories are created automatically on first run so
  theme conversion and loading work without manual folder setup.

  ## Related Issues

  - Closes #48
  - Related to #49

  ## Type Of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor/cleanup
  - [x] Documentation update
  - [ ] Tests only

  ## What Changed

  - Added ensure_default_theme_dirs() in sm_logtool/ui/theme_importer.py to
    create:
      - ~/.config/sm-logtool/themes
      - ~/.config/sm-logtool/theme-sources
  - Updated CLI entry points to call directory bootstrap:
      - sm-logtool browse (_run_browse)
      - sm-logtool themes (_run_themes)
  - Added tests:
      - test_ensure_default_theme_dirs_creates_missing_paths
      - test_run_browse_ensures_default_theme_dirs
      - test_run_themes_ensures_default_theme_dirs
  - Updated docs in README.md and docs/SEARCH_NOTES.md.

  ## Testing

  List the commands you ran and their results.

  pytest -q  # passed
  python -m unittest discover test  # passed

  ## UI Changes (if applicable)

  - [x] No UI changes
  - [ ] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not main).
  - [x] I added or updated tests for behavior changes.
  - [x] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.