### PR TITLE
Feature/issue 54

### DIFF
--- a/sm_logtool/syntax.py
+++ b/sm_logtool/syntax.py
@@ -60,6 +60,7 @@ _STATUS_BAD = re.compile(
 _STATUS_BLOCKED_OUTCOME = re.compile(
     r"\baction:\s*movetojunk\b"
     r"|\bon their blocked list\b"
+    r"|\bon the blocked country list\b"
     r"|\bmessage blocked\b",
     re.IGNORECASE,
 )

--- a/test/test_syntax.py
+++ b/test/test_syntax.py
@@ -141,3 +141,17 @@ def test_block_outcome_markers_are_highlighted_as_bad_status():
         reason_start,
         reason_end,
     )
+
+    country_line = (
+        "00:06:04.000 [84012980] REASON: Sender domain "
+        "<sender@example.test> is on the blocked country list."
+    )
+    country_spans = spans_for_line("delivery", country_line)
+    country_start = country_line.index("on the blocked country list")
+    country_end = country_start + len("on the blocked country list")
+    assert _has_span(
+        country_spans,
+        TOKEN_STATUS_BAD,
+        country_start,
+        country_end,
+    )


### PR DESCRIPTION
  # Summary

  Refine syntax highlighting to reduce false positives for `Blocked` and `Failed`
  while preserving error highlighting for true block/failure outcomes.

  ## Related Issues

  - Closes #54

  ## Type Of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor/cleanup
  - [ ] Documentation update
  - [x] Tests only

  ## What Changed

  - Updated bad-status token matching in `sm_logtool/syntax.py`:
    - Removed blanket `blocked` keyword highlighting.
    - Kept `failed` highlighting, but excluded status-field form
      `Failed: True/False`.
  - Added explicit blocked-outcome markers to highlight as errors:
    - `Action: MoveToJunk`
    - `on their blocked list`
    - `on the blocked country list`
    - `message blocked`
  - Added/updated syntax regression tests in `test/test_syntax.py`:
    - `Blocked Sender Checks started/completed` is not highlighted as error.
    - `Failed: False` in spool status line is not highlighted as error.
    - True block outcome phrases remain highlighted as error.

  ## Testing

  pytest -q
  python -m unittest discover test

  Both passed.

  ## UI Changes (if applicable)

  - [x] No UI changes
  - [ ] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not main).
  - [x] I added or updated tests for behavior changes.
  - [ ] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.
