### PR TITLE
Add standardized release notes template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ Add cases under `test/test_*.py` with descriptive names. Lean on fixtures such a
   is not on `main`, stop and confirm with the user before continuing.
 - Do not add ad-hoc release-note files under `docs/` unless explicitly requested.
   Provide release notes directly to the user or in PR/release metadata by default.
+- Use `docs/RELEASE_NOTES_TEMPLATE.md` as the standard format when drafting
+  release notes for publishing.
 
 ## Security & Configuration Tips
 Treat SmarterMail logs as sensitive—redact personal data before sharing. Always work on staged copies, copying prior-day files once and refreshing today’s log before each search. Keep environment-specific config out of git, and document any operational caveats when changing filesystem behavior.

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ python -m unittest discover test
 - [Code of Conduct](CODE_OF_CONDUCT.md)
 - [Search Design Notes](docs/SEARCH_NOTES.md)
 - [Syntax Highlighting Notes](docs/syntax_highlighting.md)
+- [Release Notes Template](docs/RELEASE_NOTES_TEMPLATE.md)
 
 ## License
 

--- a/docs/RELEASE_NOTES_TEMPLATE.md
+++ b/docs/RELEASE_NOTES_TEMPLATE.md
@@ -1,0 +1,75 @@
+# Release Notes Template
+
+Use this template for all `sm-logtool` releases so published notes stay
+consistent in structure and detail.
+
+## Standard Format
+
+```md
+# sm-logtool vX.Y.Z
+
+<1-2 sentence summary of what this release delivers and why it matters.>
+
+## Highlights
+
+- <Top user-visible change #1>
+- <Top user-visible change #2>
+- <Top user-visible change #3>
+
+## Included Issues
+
+- #<id> <short issue title>
+- #<id> <short issue title>
+
+## Included PRs
+
+- #<id> <short PR title>
+- #<id> <short PR title>
+
+## Validation
+
+- `pytest -q`
+- `python -m unittest discover test`
+- <any release-specific checks, if used>
+
+All checks passed.
+
+## Upgrade
+
+```bash
+pipx upgrade sm-logtool
+# or
+python -m pip install --upgrade sm-logtool
+```
+
+If this release changes optional speedups behavior:
+
+```bash
+pipx install --force "sm-logtool[speedups]"
+# or
+python -m pip install --upgrade "sm-logtool[speedups]"
+```
+
+## Full Changelog
+
+https://github.com/T313C0mun1s7/sm-logtool/compare/vX.Y.(Z-1)...vX.Y.Z
+```
+
+## Writing Rules
+
+- Keep `Highlights` focused on user-visible behavior.
+- Keep issue and PR lists concise and complete for that release scope.
+- Include exact validation commands that were actually run.
+- Include upgrade commands in every release note.
+- Add sections only when needed, for example:
+  - `Breaking Changes`
+  - `Known Limitations`
+  - `Docs`
+  - `Security`
+
+## Process Notes
+
+- Preferred: publish release notes in GitHub Release metadata.
+- Do not commit ad-hoc `docs/release_*.md` files unless explicitly requested.
+- If a repo-stored release note file is explicitly requested, name it
+  `docs/release_X.Y.Z.md` and follow this template.


### PR DESCRIPTION
# Summary

  Adds a standardized release notes template to reduce formatting/content drift across releases, and links it in core project docs so release drafting follows one consistent structure.

  ## Related Issues

  - Closes #N/A
  - Related to #N/A

  ## Type Of Change

  - [ ] Bug fix
  - [ ] New feature
  - [x] Refactor/cleanup
  - [x] Documentation update
  - [ ] Tests only

  ## What Changed

  - Added `docs/RELEASE_NOTES_TEMPLATE.md` with a standard release-note format:
    - title/version, summary, highlights, included issues/PRs, validation, upgrade, full changelog.
  - Added writing/process rules for release notes (including when to use optional sections).
  - Updated documentation references:
    - `README.md` now links to the release notes template.
    - `AGENTS.md` now directs release-note drafting to this template.

  ## Testing

  Docs/process-only change; no runtime behavior changes.

  ```bash
  # Not run (documentation/process updates only)
```
  ## UI Changes (if applicable)

  - [x] No UI changes
  - [ ] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not main).
  - [ ] I added or updated tests for behavior changes.
  - [x] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.

