### PR TITLE
Track standards audit backlog in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,29 @@ Add cases under `test/test_*.py` with descriptive names. Lean on fixtures such a
 - Use `docs/RELEASE_NOTES_TEMPLATE.md` as the standard format when drafting
   release notes for publishing.
 
+## Standards Audit Backlog (2026-02-26)
+- [ ] [Issue #61](https://github.com/T313C0mun1s7/sm-logtool/issues/61):
+  Ensure unittest discovery runs the real test suite.
+- [ ] [Issue #62](https://github.com/T313C0mun1s7/sm-logtool/issues/62):
+  Refactor `sm_logtool/ui/app.py` into smaller units and reduce nesting.
+- [ ] [Issue #63](https://github.com/T313C0mun1s7/sm-logtool/issues/63):
+  Refactor CLI parser/search orchestration for maintainability.
+- [ ] [Issue #64](https://github.com/T313C0mun1s7/sm-logtool/issues/64):
+  Close public API docstring gaps and add enforcement.
+- [ ] [Issue #65](https://github.com/T313C0mun1s7/sm-logtool/issues/65):
+  Enforce the 79-character line-length policy.
+- [ ] [Issue #66](https://github.com/T313C0mun1s7/sm-logtool/issues/66):
+  Remove tracked environment-specific config and document sample config
+  workflow.
+- [ ] [Issue #67](https://github.com/T313C0mun1s7/sm-logtool/issues/67):
+  Optimize live search preview rendering to reduce redraw churn.
+- [ ] [Issue #68](https://github.com/T313C0mun1s7/sm-logtool/issues/68):
+  Deduplicate ungrouped log-kind mapping across modules.
+- [ ] [Issue #69](https://github.com/T313C0mun1s7/sm-logtool/issues/69):
+  Move pytest tooling out of runtime dependencies.
+- [ ] [Issue #70](https://github.com/T313C0mun1s7/sm-logtool/issues/70):
+  Add standards-compliance checks to CI.
+
 ## Security & Configuration Tips
 Treat SmarterMail logs as sensitive—redact personal data before sharing. Always work on staged copies, copying prior-day files once and refreshing today’s log before each search. Keep environment-specific config out of git, and document any operational caveats when changing filesystem behavior.
 The default runtime config path is per-user: `~/.config/sm-logtool/config.yaml`.

--- a/docs/SEARCH_NOTES.md
+++ b/docs/SEARCH_NOTES.md
@@ -114,6 +114,35 @@ Search handlers currently exist for:
 - [x] Improve large-log performance and responsiveness (progress feedback,
   background work, reduced memory footprint, index reuse).
 
+## Audit Backlog (2026-02-26)
+
+Cross-project tracking items from the standards audit:
+
+- [ ] [Issue #61](https://github.com/T313C0mun1s7/sm-logtool/issues/61):
+  ensure unittest discovery runs the real test suite.
+- [ ] [Issue #62](https://github.com/T313C0mun1s7/sm-logtool/issues/62):
+  refactor `sm_logtool/ui/app.py` into smaller units and reduce nesting.
+- [ ] [Issue #63](https://github.com/T313C0mun1s7/sm-logtool/issues/63):
+  refactor CLI parser/search orchestration for maintainability.
+- [ ] [Issue #64](https://github.com/T313C0mun1s7/sm-logtool/issues/64):
+  close public API docstring gaps and add enforcement.
+- [ ] [Issue #65](https://github.com/T313C0mun1s7/sm-logtool/issues/65):
+  enforce the 79-character line-length policy.
+- [ ] [Issue #66](https://github.com/T313C0mun1s7/sm-logtool/issues/66):
+  remove tracked environment-specific config and document sample config
+  workflow.
+
+Search-focused optimization and structure items:
+
+- [ ] [Issue #67](https://github.com/T313C0mun1s7/sm-logtool/issues/67):
+  optimize live search preview rendering to reduce redraw churn.
+- [ ] [Issue #68](https://github.com/T313C0mun1s7/sm-logtool/issues/68):
+  deduplicate ungrouped log-kind mapping across modules.
+- [ ] [Issue #69](https://github.com/T313C0mun1s7/sm-logtool/issues/69):
+  move pytest tooling out of runtime dependencies.
+- [ ] [Issue #70](https://github.com/T313C0mun1s7/sm-logtool/issues/70):
+  add standards-compliance checks to CI.
+
 ## Notes
 
 - Historical bash behavior is useful context, but current product behavior is


### PR DESCRIPTION
# Summary

Add documentation-only backlog tracking for the standards audit so remediation work is explicitly tracked in-repo and linked to GitHub issues.

## Related Issues

- Closes #
- Related to #61
- Related to #62
- Related to #63
- Related to #64
- Related to #65
- Related to #66
- Related to #67
- Related to #68
- Related to #69
- Related to #70

## Type Of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/cleanup
- [x] Documentation update
- [ ] Tests only

## What Changed

- Added a dated "Standards Audit Backlog (2026-02-26)" section to `AGENTS.md`.
- Added a dated "Audit Backlog (2026-02-26)" section to `docs/SEARCH_NOTES.md`.
- Linked each backlog item to GitHub issues #61-#70.

## Testing

List the commands you ran and their results.

```bash
pytest -q  # not run (documentation-only change)
python -m unittest discover test  # not run (documentation-only change)
```

## UI Changes (if applicable)

- [x] No UI changes
- [ ] UI changed (attach screenshots or terminal captures)

## Security And Data Handling

- [x] I did not include sensitive log data in this PR.
- [x] I redacted any personal or customer data used in examples/screenshots.

## Checklist

- [x] I used a feature branch (not `main`).
- [ ] I added or updated tests for behavior changes.
- [x] I updated docs (`README.md`, `CONTRIBUTING.md`, or `docs/`) as needed.
- [x] I used present tense in user-facing docs.
