### PR TITLE
Run pytest suite from unittest discovery bridge

### DIFF
--- a/test/test_unittest_pytest_bridge.py
+++ b/test/test_unittest_pytest_bridge.py
@@ -1,0 +1,53 @@
+"""Unittest bridge that executes the pytest suite."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+
+
+def _running_under_pytest() -> bool:
+    argv = " ".join(sys.argv).lower()
+    return "pytest" in argv
+
+
+@unittest.skipIf(
+    _running_under_pytest(),
+    "Bridge test is only used by unittest discover.",
+)
+class TestPytestBridge(unittest.TestCase):
+    """Run pytest from unittest discover to keep both entrypoints valid."""
+
+    def test_pytest_suite_passes(self) -> None:
+        repo_root = Path(__file__).resolve().parent.parent
+        bridge_path = Path(__file__).resolve()
+        command = [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            "--ignore",
+            str(bridge_path),
+        ]
+        completed = subprocess.run(
+            command,
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if completed.returncode == 0:
+            return
+
+        details = "\n".join(
+            [
+                "pytest bridge failed.",
+                f"Command: {' '.join(command)}",
+                f"Exit code: {completed.returncode}",
+                f"stdout:\n{completed.stdout}",
+                f"stderr:\n{completed.stderr}",
+            ]
+        )
+        self.fail(details)


### PR DESCRIPTION
  # Summary

  Ensure `python -m unittest discover test` executes meaningful project tests by adding a unittest bridge that runs the pytest suite.

  ## Related Issues

  - Closes #61
  - Related to #

  ## Type Of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor/cleanup
  - [ ] Documentation update
  - [ ] Tests only

  ## What Changed

  - Added `test/test_unittest_pytest_bridge.py`.
  - Implemented a unittest test case that runs `pytest -q` in a subprocess.
  - Configured the bridge to skip itself under pytest to prevent recursion/duplication.

  ## Testing

  List the commands you ran and their results.

  ```bash
  pytest -q
  python -m unittest discover test
```

  - pytest -q: pass
  - python -m unittest discover test -v: pass (Ran 2 tests, including bridge test)

  ## UI Changes (if applicable)

  - [x] No UI changes
  - [ ] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not main).
  - [x] I added or updated tests for behavior changes.
  - [ ] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.
