### PR TITLE
Add public API docstrings and enforce coverage

### DIFF
--- a/sm_logtool/logfiles.py
+++ b/sm_logtool/logfiles.py
@@ -32,6 +32,8 @@ class LogFileInfo:
 
     @property
     def base_name(self) -> str:
+        """Return filename without a trailing ``.zip`` wrapper."""
+
         return self.path.name[:-4] if self.is_zipped else self.path.name
 
 

--- a/sm_logtool/result_formatting.py
+++ b/sm_logtool/result_formatting.py
@@ -32,6 +32,8 @@ from .search import Conversation
 
 @dataclass
 class ColumnWidths:
+    """Maximum widths used to align parsed log columns."""
+
     time: int = 0
     ip: int = 0
     log_id: int = 0

--- a/sm_logtool/search.py
+++ b/sm_logtool/search.py
@@ -109,10 +109,14 @@ class SmtpSearchResult:
 
     @property
     def total_conversations(self) -> int:
+        """Return the number of grouped conversations in ``conversations``."""
+
         return len(self.conversations)
 
 
 class SearchFunction(Protocol):
+    """Callable signature used by all search handlers."""
+
     def __call__(
         self,
         log_path: Path,
@@ -448,6 +452,8 @@ def search_ungrouped_entries(
 
 
 def normalize_materialization_mode(value: str) -> str:
+    """Normalize and validate grouped-search materialization strategy."""
+
     mode = value.strip().lower()
     if mode in SUPPORTED_MATERIALIZATION_MODES:
         return mode
@@ -1661,12 +1667,16 @@ def _owner_strategy_for_kind(
 
 
 def has_search_index(log_path: Path, kind: str) -> bool:
+    """Return whether an owner index is cached for ``log_path`` and ``kind``."""
+
     owner_key, _owner_for_line = _owner_strategy_for_kind(kind)
     cache_key, _signature = _owner_index_cache_key(log_path, owner_key)
     return _lookup_owner_line_index(cache_key) is not None
 
 
 def prime_search_index(log_path: Path, kind: str) -> None:
+    """Build and cache a search owner index for ``log_path`` and ``kind``."""
+
     owner_key, owner_for_line = _owner_strategy_for_kind(kind)
     cache_key, signature = _owner_index_cache_key(log_path, owner_key)
     if _lookup_owner_line_index(cache_key) is not None:

--- a/sm_logtool/ui/app.py
+++ b/sm_logtool/ui/app.py
@@ -755,6 +755,8 @@ class ContextMenuScreen(ModalScreen[str | None]):
 
 
 class TopActionPressed(Message):
+    """Event message emitted when a top action is triggered."""
+
     def __init__(self, sender: "TopAction", action: str) -> None:
         super().__init__()
         self.sender = sender
@@ -817,6 +819,8 @@ class TopAction(Static):
 
 
 class WizardStep(Enum):
+    """Wizard stages for the log-browser workflow."""
+
     KIND = auto()
     DATE = auto()
     SEARCH = auto()
@@ -1109,6 +1113,8 @@ def _search_targets_in_thread_pool(
 
 
 class KindListItem(ListItem):
+    """Selectable list item representing a log kind."""
+
     def __init__(self, kind: str) -> None:
         self.label_widget = Static(kind, classes="label")
         super().__init__(self.label_widget)
@@ -1138,6 +1144,8 @@ class KindListView(ListView):
 
 
 class DateListItem(ListItem):
+    """Selectable list item representing a single dated log file."""
+
     def __init__(
         self,
         info: LogFileInfo,
@@ -1177,6 +1185,8 @@ class DateListItem(ListItem):
 
 
 class DateSelectionChanged(Message):
+    """Event message emitted when selected date rows change."""
+
     def __init__(
         self,
         sender: "DateListView",
@@ -1188,6 +1198,8 @@ class DateSelectionChanged(Message):
 
 
 class WizardBody(Vertical):
+    """Root container for wizard step content and shortcuts."""
+
     can_focus = True
     BINDINGS = [
         Binding(
@@ -1252,6 +1264,8 @@ class WizardBody(Vertical):
 
 
 class SearchInput(Input, inherit_bindings=False):
+    """Search input widget with custom key bindings."""
+
     BINDINGS = [
         Binding("left", "cursor_left", show=False),
         Binding("right", "cursor_right", show=False),
@@ -1264,6 +1278,8 @@ class SearchInput(Input, inherit_bindings=False):
 
 
 class MnemonicFooterKey(FooterKey):
+    """Footer key renderer that bolds mnemonic characters."""
+
     def __init__(
         self,
         *args: object,
@@ -1313,6 +1329,8 @@ class MnemonicFooterKey(FooterKey):
 
 
 class MenuFooter(Footer):
+    """Footer variant with mnemonic-aware key labels."""
+
     def _mnemonic_index(self, binding: Binding) -> int | None:
         description = binding.description
         if not description:
@@ -1539,6 +1557,8 @@ class DateListView(ListView):
 
     @property
     def selected_infos(self) -> list[LogFileInfo]:
+        """Return currently selected log file infos in list order."""
+
         infos: list[LogFileInfo] = []
         for idx, child in enumerate(self.children):
             if not isinstance(child, DateListItem):

--- a/test/test_public_docstrings.py
+++ b/test/test_public_docstrings.py
@@ -1,0 +1,64 @@
+"""Checks for public API docstring coverage in production modules."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _is_property_method(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    for decorator in node.decorator_list:
+        if isinstance(decorator, ast.Name) and decorator.id == "property":
+            return True
+        if isinstance(decorator, ast.Attribute) and decorator.attr == "setter":
+            return True
+    return False
+
+
+def _missing_public_docstrings(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    missing: list[str] = []
+
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            child.parent = parent
+
+    for node in tree.body:
+        if not isinstance(
+            node,
+            (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef),
+        ):
+            continue
+        if node.name.startswith("_"):
+            continue
+        if ast.get_docstring(node) is None:
+            missing.append(f"{path}:{node.lineno} top-level {node.name}")
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        parent = getattr(node, "parent", None)
+        if not isinstance(parent, ast.ClassDef):
+            continue
+        if parent.name.startswith("_") or node.name.startswith("_"):
+            continue
+        if not _is_property_method(node):
+            continue
+        if ast.get_docstring(node) is None:
+            name = f"{parent.name}.{node.name}"
+            missing.append(f"{path}:{node.lineno} property {name}")
+    return missing
+
+
+def test_public_api_docstrings_present() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    package_root = project_root / "sm_logtool"
+    missing: list[str] = []
+
+    for path in sorted(package_root.rglob("*.py")):
+        missing.extend(_missing_public_docstrings(path))
+
+    assert not missing, (
+        "Missing public API docstrings:\n"
+        + "\n".join(missing)
+    )


### PR DESCRIPTION
  # Summary

  Add missing public API docstrings in production modules and introduce an automated docstring coverage check so regressions fail in tests.

  ## Related Issues

  - Closes #64
  - Related to #

  ## Type Of Change

  - [ ] Bug fix
  - [ ] New feature
  - [x] Refactor/cleanup
  - [x] Documentation update
  - [ ] Tests only

  ## What Changed

  - Added missing docstrings to public API surfaces in:
  - sm_logtool/logfiles.py
  - sm_logtool/result_formatting.py
  - sm_logtool/search.py
  - sm_logtool/ui/app.py
  - Added lightweight enforcement test:
  - test/test_public_docstrings.py
  - Enforcement scope:
  - Public top-level classes/functions in sm_logtool/
  - Public @property methods on public classes
  - The test reports concrete file/line entries when docstrings are missing.

  ## Testing

  List the commands you ran and their results.

  Commands run:

  - pytest -q test/test_public_docstrings.py
  - pytest -q test/test_cli.py test/test_search.py
  - pytest -q test/test_ui_bindings.py
  - pytest -q
  - python -m unittest discover test -q

  Results:

  - pytest -q test/test_public_docstrings.py: pass
  - pytest -q test/test_cli.py test/test_search.py: pass
  - pytest -q test/test_ui_bindings.py: pass
  - pytest -q: pass
  - python -m unittest discover test -q: pass (Ran 2 tests)

  ## UI Changes (if applicable)

  - [x] No UI changes
  - [ ] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not main).
  - [ ] I added or updated tests for behavior changes.
  - [ ] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.