### PR TITLE
Enforce production line-length policy checks

### DIFF
--- a/scripts/check_release_defaults.py
+++ b/scripts/check_release_defaults.py
@@ -77,7 +77,8 @@ def main() -> int:
     repo_theme = _load_top_level_scalar(Path("config.yaml"), "theme")
     if repo_theme != EXPECTED_THEME:
         failures.append(
-            f"config.yaml theme is {repo_theme!r}, expected {EXPECTED_THEME!r}."
+            "config.yaml theme is "
+            f"{repo_theme!r}, expected {EXPECTED_THEME!r}."
         )
 
     if failures:

--- a/sm_logtool/search.py
+++ b/sm_logtool/search.py
@@ -1667,7 +1667,10 @@ def _owner_strategy_for_kind(
 
 
 def has_search_index(log_path: Path, kind: str) -> bool:
-    """Return whether an owner index is cached for ``log_path`` and ``kind``."""
+    """Return whether an owner index is cached.
+
+    The cache key is scoped by ``log_path`` and ``kind``.
+    """
 
     owner_key, _owner_for_line = _owner_strategy_for_kind(kind)
     cache_key, _signature = _owner_index_cache_key(log_path, owner_key)

--- a/sm_logtool/search_planning.py
+++ b/sm_logtool/search_planning.py
@@ -45,7 +45,10 @@ def choose_search_execution_plan(
         return SearchExecutionPlan(bounded_workers, "indexed large workload")
 
     if total_bytes <= 0:
-        return SearchExecutionPlan(bounded_workers, "workload size unavailable")
+        return SearchExecutionPlan(
+            bounded_workers,
+            "workload size unavailable",
+        )
 
     per_target = total_bytes / target_count
     if target_count == 2 and total_bytes < _SMALL_TWO_TARGET_BYTES:

--- a/sm_logtool/syntax.py
+++ b/sm_logtool/syntax.py
@@ -291,7 +291,9 @@ def _response_code_spans(line: str, offset: int) -> list[HighlightSpan]:
             continue
         start = payload_start + code_match.start(1)
         end = payload_start + code_match.end(1)
-        spans.append(HighlightSpan(offset + start, offset + end, TOKEN_RESPONSE))
+        spans.append(
+            HighlightSpan(offset + start, offset + end, TOKEN_RESPONSE),
+        )
     return spans
 
 

--- a/sm_logtool/ui/app.py
+++ b/sm_logtool/ui/app.py
@@ -2452,7 +2452,9 @@ class LogBrowser(App):
                 self._show_step_results()
                 lines = ["[search error]", message]
                 if self._live_execution_label:
-                    lines.extend(["", "[execution]", self._live_execution_label])
+                    lines.extend(
+                        ["", "[execution]", self._live_execution_label],
+                    )
                 self._write_output_lines(lines)
             self._notify(message)
             return
@@ -3296,7 +3298,10 @@ class LogBrowser(App):
         target_name: str,
     ) -> None:
         percent = int((current / total) * 100) if total else 0
-        detail = f"{phase} {current}/{total} log(s) ({percent}%): {target_name}"
+        detail = (
+            f"{phase} {current}/{total} log(s) "
+            f"({percent}%): {target_name}"
+        )
         self._notify(detail)
         self._set_live_progress(detail, percent)
 

--- a/test/test_line_length_policy.py
+++ b/test/test_line_length_policy.py
@@ -1,0 +1,42 @@
+"""Enforce the 79-character limit for production Python files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+MAX_LINE_LENGTH = 79
+TARGET_DIRECTORIES = ("sm_logtool", "scripts")
+LINE_LENGTH_EXCEPTIONS: dict[str, set[int]] = {}
+
+
+def _line_length_violations(path: Path, root: Path) -> list[str]:
+    relative_path = path.relative_to(root).as_posix()
+    exceptions = LINE_LENGTH_EXCEPTIONS.get(relative_path, set())
+    violations: list[str] = []
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for line_number, line in enumerate(lines, 1):
+        if len(line) <= MAX_LINE_LENGTH:
+            continue
+        if line_number in exceptions:
+            continue
+        length = len(line)
+        violations.append(
+            f"{relative_path}:{line_number} has {length} characters",
+        )
+    return violations
+
+
+def test_production_python_line_lengths() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    violations: list[str] = []
+
+    for directory in TARGET_DIRECTORIES:
+        base = project_root / directory
+        for path in sorted(base.rglob("*.py")):
+            violations.extend(_line_length_violations(path, project_root))
+
+    assert not violations, (
+        "Production line-length violations detected:\n"
+        + "\n".join(violations)
+    )


### PR DESCRIPTION
 # Summary

  Enforces the repository’s 79-character line-length standard by fixing existing production outliers and adding an automated test to prevent regressions.

  ## Related Issues

  - Closes #65
  - Related to #N/A

  ## Type Of Change

  - [x] Bug fix
  - [ ] New feature
  - [x] Refactor/cleanup
  - [ ] Documentation update
  - [x] Tests only

  ## What Changed

  - Wrapped current line-length outliers in production code and scripts:
  - sm_logtool/search.py
  - sm_logtool/search_planning.py
  - sm_logtool/syntax.py
  - sm_logtool/ui/app.py
  - scripts/check_release_defaults.py
  - Added test/test_line_length_policy.py:
  - Enforces <=79 characters for Python files under sm_logtool/ and scripts/
  - Supports explicit future exceptions through a centralized LINE_LENGTH_EXCEPTIONS map if ever needed

  ## Testing

  List the commands you ran and their results.

  - pytest -q -> pass
  - python -m unittest discover test -> pass (Ran 2 tests, OK)

  ## UI Changes (if applicable)

  - [x] No UI changes
  - [ ] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not main).
  - [x] I added or updated tests for behavior changes.
  - [x] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.