### PR TITLE
Replace tracked runtime config with template workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,7 @@ cython_debug/
 sample_logs/*
 !sample_logs/README.txt
 artifacts/
+/config.yaml
 
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,12 @@ Add cases under `test/test_*.py` with descriptive names. Lean on fixtures such a
   Add standards-compliance checks to CI.
 
 ## Security & Configuration Tips
-Treat SmarterMail logs as sensitive—redact personal data before sharing. Always work on staged copies, copying prior-day files once and refreshing today’s log before each search. Keep environment-specific config out of git, and document any operational caveats when changing filesystem behavior.
+Treat SmarterMail logs as sensitive—redact personal data before sharing.
+Always work on staged copies, copying prior-day files once and refreshing
+today’s log before each search. Keep environment-specific config out of git,
+and document any operational caveats when changing filesystem behavior.
+Use `config.example.yaml` as the bootstrap template; do not commit a live
+runtime `config.yaml`.
 The default runtime config path is per-user: `~/.config/sm-logtool/config.yaml`.
 Theme import sources and converted themes are also per-user:
 `~/.config/sm-logtool/theme-sources` and `~/.config/sm-logtool/themes`.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,18 @@ default_kind: smtp
 theme: Cyberdark
 ```
 
+Repository template:
+
+- `config.example.yaml` is a sample config for local bootstrap.
+- The repository does not track a live runtime `config.yaml`.
+
+Bootstrap a per-user config from the template:
+
+```bash
+mkdir -p ~/.config/sm-logtool
+cp config.example.yaml ~/.config/sm-logtool/config.yaml
+```
+
 If `staging_dir` does not exist yet, the app creates it automatically.
 
 Default config location is per-user:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,3 +1,5 @@
+# Sample sm-logtool runtime config.
+# Copy to ~/.config/sm-logtool/config.yaml or pass with --config.
 logs_dir: /var/lib/smartermail/Logs
 staging_dir: /var/tmp/sm-logtool/logs
 default_kind: smtp

--- a/docs/SEARCH_NOTES.md
+++ b/docs/SEARCH_NOTES.md
@@ -34,6 +34,8 @@ Search handlers currently exist for:
 - Search runs on staged copies so source logs stay untouched.
 - `.zip` inputs are extracted to staging before search.
 - Staging directories are created automatically if missing.
+- Runtime config is per-user (`~/.config/sm-logtool/config.yaml`); use
+  `config.example.yaml` as a local bootstrap template.
 
 ### Grouping and rendering
 

--- a/scripts/check_release_defaults.py
+++ b/scripts/check_release_defaults.py
@@ -13,6 +13,7 @@ import sys
 
 
 EXPECTED_THEME = "Cyberdark"
+SAMPLE_CONFIG_PATH = Path("config.example.yaml")
 
 
 def _load_default_theme_constant(path: Path) -> str:
@@ -74,10 +75,10 @@ def main() -> int:
             f"is {module_theme!r}, expected {EXPECTED_THEME!r}."
         )
 
-    repo_theme = _load_top_level_scalar(Path("config.yaml"), "theme")
+    repo_theme = _load_top_level_scalar(SAMPLE_CONFIG_PATH, "theme")
     if repo_theme != EXPECTED_THEME:
         failures.append(
-            "config.yaml theme is "
+            f"{SAMPLE_CONFIG_PATH} theme is "
             f"{repo_theme!r}, expected {EXPECTED_THEME!r}."
         )
 
@@ -89,7 +90,8 @@ def main() -> int:
 
     print(
         "Release default checks passed: "
-        f"DEFAULT_THEME={module_theme!r}, config.yaml theme={repo_theme!r}."
+        f"DEFAULT_THEME={module_theme!r}, "
+        f"{SAMPLE_CONFIG_PATH} theme={repo_theme!r}."
     )
     return 0
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -8,6 +8,18 @@ import yaml
 from sm_logtool import config
 
 
+def test_config_example_matches_runtime_defaults() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    sample_path = project_root / "config.example.yaml"
+
+    payload = yaml.safe_load(sample_path.read_text(encoding="utf-8"))
+
+    assert payload["logs_dir"] == str(config.DEFAULT_LOGS_DIR)
+    assert payload["staging_dir"] == str(config.DEFAULT_STAGING_DIR)
+    assert payload["default_kind"] == config.DEFAULT_KIND
+    assert payload["theme"] == config.DEFAULT_THEME
+
+
 def test_load_config_missing_file(tmp_path):
     cfg_path = tmp_path / "config.yaml"
 


### PR DESCRIPTION
 # Summary

  Removes tracked environment-specific runtime config from the repository and replaces it with a documented sample-config bootstrap workflow, while preserving first-run auto-creation behavior for per-
  user config and theme directories.

  ## Related Issues

  - Closes #66
  - Related to #N/A

  ## Type Of Change

  - [ ] Bug fix
  - [ ] New feature
  - [x] Refactor/cleanup
  - [x] Documentation update
  - [x] Tests only

  ## What Changed

  - Replaced tracked runtime config with a template:
  - Renamed repository config.yaml to config.example.yaml
  - Added /config.yaml to .gitignore so machine-specific runtime config is not committed
  - Updated docs for bootstrap workflow:
  - README.md now documents copying config.example.yaml to ~/.config/sm-logtool/config.yaml
  - AGENTS.md now explicitly requires using config.example.yaml and not committing live runtime config
  - docs/SEARCH_NOTES.md now notes per-user runtime config + template bootstrap
  - Updated release guard:
  - scripts/check_release_defaults.py now validates theme defaults from config.example.yaml instead of config.yaml
  - Added regression coverage:
  - test/test_config.py includes test_config_example_matches_runtime_defaults to ensure template defaults stay aligned with runtime constants

  ## Testing

  List the commands you ran and their results.

  - pytest -q test/test_config.py -k 'creates_default_config_file or creates_env_config_file' -> pass
  - pytest -q test/test_cli.py -k 'run_browse_ensures_default_theme_dirs or run_themes_ensures_default_theme_dirs' -> pass
  - python scripts/check_release_defaults.py -> pass
  - pytest -q -> pass
  - python -m unittest discover test -> pass (Ran 2 tests, OK)

  ## UI Changes (if applicable)

  - [x] No UI changes
  - [ ] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not main).
  - [x] I added or updated tests for behavior changes.
  - [x] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.