### PR TITLE
Deduplicate ungrouped log-kind mappings

### DIFF
--- a/sm_logtool/log_kinds.py
+++ b/sm_logtool/log_kinds.py
@@ -44,6 +44,26 @@ SUPPORTED_KINDS: Final[tuple[str, ...]] = (
     KIND_WEBDAV,
 )
 
+SEARCH_UNGROUPED_KINDS: Final[tuple[str, ...]] = (
+    KIND_ACTIVATION,
+    KIND_AUTOCLEANFOLDERS,
+    KIND_CALENDARS,
+    KIND_CONTENTFILTER,
+    KIND_EVENT,
+    KIND_GENERALERRORS,
+    KIND_INDEXING,
+    KIND_LDAP,
+    KIND_MAINTENANCE,
+    KIND_PROFILER,
+    KIND_SPAMCHECKS,
+    KIND_WEBDAV,
+)
+
+ENTRY_RENDER_KINDS: Final[tuple[str, ...]] = (
+    KIND_ADMINISTRATIVE,
+    *SEARCH_UNGROUPED_KINDS,
+)
+
 _KIND_ALIASES: Final[dict[str, str]] = {
     KIND_SMTP: KIND_SMTP,
     "smtplog": KIND_SMTP,
@@ -76,3 +96,15 @@ def normalize_kind(value: str) -> str:
 
     key = value.strip().lower()
     return _KIND_ALIASES.get(key, key)
+
+
+def is_search_ungrouped_kind(value: str) -> bool:
+    """Return whether ``value`` uses ungrouped search entry strategy."""
+
+    return normalize_kind(value) in SEARCH_UNGROUPED_KINDS
+
+
+def is_entry_render_kind(value: str) -> bool:
+    """Return whether ``value`` renders as entry-style results."""
+
+    return normalize_kind(value) in ENTRY_RENDER_KINDS

--- a/sm_logtool/result_rendering.py
+++ b/sm_logtool/result_rendering.py
@@ -5,43 +5,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Sequence
 
-from .log_kinds import (
-    KIND_ACTIVATION,
-    KIND_ADMINISTRATIVE,
-    KIND_AUTOCLEANFOLDERS,
-    KIND_CALENDARS,
-    KIND_CONTENTFILTER,
-    KIND_EVENT,
-    KIND_GENERALERRORS,
-    KIND_INDEXING,
-    KIND_LDAP,
-    KIND_MAINTENANCE,
-    KIND_PROFILER,
-    KIND_SPAMCHECKS,
-    KIND_WEBDAV,
-    normalize_kind,
-)
+from .log_kinds import is_entry_render_kind
 from .result_modes import normalize_result_mode
 from .result_modes import RESULT_MODE_MATCHING_ROWS
 from .result_modes import RESULT_MODE_RELATED_TRAFFIC
 from .result_formatting import collect_widths, format_conversation_lines
 from .search import SmtpSearchResult
-
-UNGROUPED_KINDS = {
-    KIND_ADMINISTRATIVE,
-    KIND_ACTIVATION,
-    KIND_AUTOCLEANFOLDERS,
-    KIND_CALENDARS,
-    KIND_CONTENTFILTER,
-    KIND_EVENT,
-    KIND_GENERALERRORS,
-    KIND_INDEXING,
-    KIND_LDAP,
-    KIND_MAINTENANCE,
-    KIND_PROFILER,
-    KIND_SPAMCHECKS,
-    KIND_WEBDAV,
-}
 
 
 def render_search_results(
@@ -57,8 +26,7 @@ def render_search_results(
     resolved_result_mode = normalize_result_mode(result_mode)
 
     rendered_lines: list[str] = []
-    kind_key = normalize_kind(kind)
-    is_ungrouped = kind_key in UNGROUPED_KINDS
+    is_ungrouped = is_entry_render_kind(kind)
     label = "entry" if is_ungrouped else "conversation"
 
     for result, target in zip(results, targets):

--- a/sm_logtool/search.py
+++ b/sm_logtool/search.py
@@ -13,24 +13,13 @@ import time
 from typing import Callable, List, Protocol, Tuple
 
 from .log_kinds import (
-    KIND_ACTIVATION,
     KIND_ADMINISTRATIVE,
-    KIND_AUTOCLEANFOLDERS,
-    KIND_CALENDARS,
-    KIND_CONTENTFILTER,
     KIND_DELIVERY,
-    KIND_EVENT,
-    KIND_GENERALERRORS,
     KIND_IMAP,
     KIND_IMAP_RETRIEVAL,
-    KIND_INDEXING,
-    KIND_LDAP,
-    KIND_MAINTENANCE,
     KIND_POP,
-    KIND_PROFILER,
     KIND_SMTP,
-    KIND_SPAMCHECKS,
-    KIND_WEBDAV,
+    is_search_ungrouped_kind,
     normalize_kind,
 )
 from .log_parsers import (
@@ -1648,20 +1637,7 @@ def _owner_strategy_for_kind(
         return "admin", _admin_owner_id
     if kind_key == KIND_IMAP_RETRIEVAL:
         return "imap-retrieval", _imap_retrieval_owner_id
-    if kind_key in {
-        KIND_ACTIVATION,
-        KIND_AUTOCLEANFOLDERS,
-        KIND_CALENDARS,
-        KIND_CONTENTFILTER,
-        KIND_EVENT,
-        KIND_GENERALERRORS,
-        KIND_INDEXING,
-        KIND_LDAP,
-        KIND_MAINTENANCE,
-        KIND_PROFILER,
-        KIND_SPAMCHECKS,
-        KIND_WEBDAV,
-    }:
+    if is_search_ungrouped_kind(kind_key):
         return "ungrouped", None
     raise ValueError(f"Unsupported log kind: {kind}")
 
@@ -1757,19 +1733,6 @@ def get_search_function(
         return search_admin_entries
     if kind_key == KIND_IMAP_RETRIEVAL:
         return search_imap_retrieval_entries
-    if kind_key in {
-        KIND_ACTIVATION,
-        KIND_AUTOCLEANFOLDERS,
-        KIND_CALENDARS,
-        KIND_CONTENTFILTER,
-        KIND_EVENT,
-        KIND_GENERALERRORS,
-        KIND_INDEXING,
-        KIND_LDAP,
-        KIND_MAINTENANCE,
-        KIND_PROFILER,
-        KIND_SPAMCHECKS,
-        KIND_WEBDAV,
-    }:
+    if is_search_ungrouped_kind(kind_key):
         return search_ungrouped_entries
     return None

--- a/test/test_log_kinds.py
+++ b/test/test_log_kinds.py
@@ -1,0 +1,22 @@
+from sm_logtool import log_kinds
+
+
+def test_search_ungrouped_kinds_exclude_administrative() -> None:
+    assert log_kinds.is_search_ungrouped_kind("activation")
+    assert log_kinds.is_search_ungrouped_kind("webdav")
+    assert not log_kinds.is_search_ungrouped_kind("administrative")
+
+
+def test_entry_render_kinds_include_administrative() -> None:
+    assert log_kinds.is_entry_render_kind("administrative")
+    assert log_kinds.is_entry_render_kind("activation")
+    assert not log_kinds.is_entry_render_kind("smtp")
+
+
+def test_entry_render_kinds_cover_search_ungrouped_kinds() -> None:
+    missing = [
+        kind
+        for kind in log_kinds.SEARCH_UNGROUPED_KINDS
+        if kind not in log_kinds.ENTRY_RENDER_KINDS
+    ]
+    assert not missing

--- a/test/test_result_rendering.py
+++ b/test/test_result_rendering.py
@@ -105,3 +105,35 @@ def test_render_matching_only_mode_for_delivery():
     assert any("matching row(s)" in line for line in lines)
     assert any("Delivery blocked by policy" in line for line in lines)
     assert not any("Queued for domain example.net" in line for line in lines)
+
+
+def test_render_related_mode_for_administrative_stays_entry_style():
+    result = SmtpSearchResult(
+        term="imap",
+        log_path=Path("administrative.log"),
+        conversations=[
+            Conversation(
+                message_id="1.1.1.1 00:00:00",
+                lines=[
+                    "00:00:00 [1.1.1.1] IMAP Session started",
+                    "00:00:01 [1.1.1.1] IMAP Auth success",
+                ],
+                first_line_number=1,
+            )
+        ],
+        total_lines=2,
+        orphan_matches=[],
+        matching_rows=[
+            (1, "00:00:00 [1.1.1.1] IMAP Session started"),
+        ],
+    )
+
+    lines = render_search_results(
+        [result],
+        [Path("administrative.log")],
+        "administrative",
+        result_mode=RESULT_MODE_RELATED_TRAFFIC,
+    )
+
+    assert any("1 entry(s)" in line for line in lines)
+    assert not any("first seen on line" in line for line in lines)

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -675,3 +675,17 @@ def test_search_match_callback_works_with_index_cache(tmp_path):
     assert hits == [
         (2, "00:00:01 [1.1.1.1][ABC123] Second line"),
     ]
+
+
+def test_get_search_function_maps_administrative_to_admin_search() -> None:
+    assert (
+        search.get_search_function("administrative")
+        is search.search_admin_entries
+    )
+
+
+def test_get_search_function_maps_activation_to_ungrouped_search() -> None:
+    assert (
+        search.get_search_function("activation")
+        is search.search_ungrouped_entries
+    )


### PR DESCRIPTION
 # Summary

  Deduplicates ungrouped log-kind mapping by introducing shared kind-classification helpers and updating search/rendering modules to use a single source of truth, reducing drift risk while preserving
  existing behavior.

  ## Related Issues

  - Closes #68
  - Related to #N/A

  ## Type Of Change

  - [ ] Bug fix
  - [ ] New feature
  - [x] Refactor/cleanup
  - [ ] Documentation update
  - [x] Tests only

  ## What Changed

  - Added centralized kind-group helpers in sm_logtool/log_kinds.py:
  - SEARCH_UNGROUPED_KINDS
  - ENTRY_RENDER_KINDS
  - is_search_ungrouped_kind(...)
  - is_entry_render_kind(...)
  - Updated sm_logtool/search.py to use shared helper logic for:
  - owner strategy selection (ungrouped vs grouped)
  - get_search_function(...) mapping
  - Updated sm_logtool/result_rendering.py to use shared helper logic for entry-style vs conversation-style rendering.
  - Removed duplicated ungrouped-kind lists from production modules.
  - Added regression tests in:
  - test/test_log_kinds.py
  - test/test_search.py
  - test/test_result_rendering.py

  ## Testing

  List the commands you ran and their results.

  - pytest -q test/test_log_kinds.py -> pass
  - pytest -q test/test_result_rendering.py -k 'administrative or matching_only_mode_for_delivery or related_mode_keeps_grouped' -> pass
  - pytest -q test/test_search.py -k 'get_search_function_maps_administrative_to_admin_search or get_search_function_maps_activation_to_ungrouped_search' -> pass
  - pytest -q -> pass
  - python -m unittest discover test -> pass (Ran 2 tests, OK)
  - Manual TUI validation across grouped/ungrouped/admin flows -> pass

  ## UI Changes (if applicable)

  - [x] No UI changes
  - [ ] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not main).
  - [x] I added or updated tests for behavior changes.
  - [ ] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.