### PR TITLE
Move pytest tooling to test optional dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .
+          python -m pip install -e ".[test]"
 
       - name: Run pytest
         run: python -m pytest -q

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,8 @@ park references in `docs/`.
 
 ## Build, Test, and Development Commands
 Create a venv (`python -m venv .venv && source .venv/bin/activate`) and
-install with `python -m pip install -e .`. Add pytest if needed, run
+install with `python -m pip install -e ".[test]"` for contributor test
+runs (or `python -m pip install -e .` for runtime-only installs). Run
 `pytest -q`, and mirror CI with `python -m unittest discover test`. Launch the
 TUI via `python -m sm_logtool.cli --logs-dir /var/lib/smartermail/Logs` or aim
 it at your staging folder.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,9 +41,9 @@ Thank you for considering contributing to the **SmarterMail Log Tool** project! 
      python -m venv .venv
      source .venv/bin/activate
      ```
-   - Install the project in editable mode with its dependencies:
+   - Install the project in editable mode with test dependencies:
      ```bash
-     python -m pip install -e .
+     python -m pip install -e ".[test]"
      ```
 
 3. **Create a New Branch**:

--- a/README.md
+++ b/README.md
@@ -310,6 +310,12 @@ Log discovery expects SmarterMail-style names such as:
 
 ## Development
 
+Install with test tooling:
+
+```bash
+python -m pip install -e ".[test]"
+```
+
 Run tests with both frameworks used in this repository:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,13 @@ dependencies = [
   "textual>=0.55",
   "rich>=13.0",
   "PyYAML>=6.0",
-  "pytest>=8",
-  "pytest-asyncio>=0.23",
 ]
 
 [project.optional-dependencies]
+test = [
+  "pytest>=8",
+  "pytest-asyncio>=0.23",
+]
 speedups = [
   "rapidfuzz>=3.0",
 ]


### PR DESCRIPTION
 # Summary

  Moves pytest tooling out of runtime dependencies by introducing a dedicated test optional dependency group, and updates CI/contributor setup to use that group for reliable test execution.

  ## Related Issues

  - Closes #69
  - Related to #N/A

  ## Type Of Change

  - [ ] Bug fix
  - [ ] New feature
  - [x] Refactor/cleanup
  - [x] Documentation update
  - [ ] Tests only

  ## What Changed

  - Updated packaging in pyproject.toml:
  - Removed pytest and pytest-asyncio from main runtime dependencies
  - Added test optional dependency group containing:
  - pytest>=8
  - pytest-asyncio>=0.23
  - Updated CI test workflow in .github/workflows/test.yml:
  - Changed install step from python -m pip install -e . to python -m pip install -e ".[test]"
  - Updated contributor/developer docs:
  - README.md now shows installing with python -m pip install -e ".[test]" for development testing
  - CONTRIBUTING.md setup instructions now install test dependencies via .[test]
  - AGENTS.md build/test section now distinguishes contributor test installs (.[test]) from runtime-only installs (-e .)

  ## Testing

  List the commands you ran and their results.

  - pytest -q -> pass
  - python -m unittest discover test -> pass (Ran 2 tests, OK)
  - python -m pip install -e ".[test]" -> unable to complete in this sandbox due restricted network access when fetching build dependencies (setuptools>=69)

  ## UI Changes (if applicable)

  - [x] No UI changes
  - [ ] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not main).
  - [ ] I added or updated tests for behavior changes.
  - [x] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.