### PR TITLE
Add 14-day staging cleanup on startup and quit

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ cp config.example.yaml ~/.config/sm-logtool/config.yaml
 ```
 
 If `staging_dir` does not exist yet, the app creates it automatically.
+On startup and quit, staged files older than 14 days are pruned
+automatically.
 
 Default config location is per-user:
 

--- a/docs/SEARCH_NOTES.md
+++ b/docs/SEARCH_NOTES.md
@@ -34,6 +34,7 @@ Search handlers currently exist for:
 - Search runs on staged copies so source logs stay untouched.
 - `.zip` inputs are extracted to staging before search.
 - Staging directories are created automatically if missing.
+- Staged files older than 14 days are pruned on app startup and quit.
 - Runtime config is per-user (`~/.config/sm-logtool/config.yaml`); use
   `config.example.yaml` as a local bootstrap template.
 

--- a/sm_logtool/staging.py
+++ b/sm_logtool/staging.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+from datetime import timezone
+import math
+import re
 import shutil
 from dataclasses import dataclass
 from datetime import date
@@ -13,6 +17,12 @@ from .logfiles import LogFileInfo, parse_log_filename
 
 
 DEFAULT_STAGING_ROOT = Path.home() / ".cache" / "sm-logtool" / "staging"
+DEFAULT_STAGING_RETENTION_DAYS = 14
+_SECONDS_PER_DAY = 24 * 60 * 60
+_STAMP_NAME_RE = re.compile(r"^(?P<stamp>\d{4}\.\d{2}\.\d{2})-")
+_SUBSEARCH_NAME_RE = re.compile(
+    r"^subsearch_\d{2}_(?P<stamp>\d{8}_\d{6})\.log$",
+)
 
 
 @dataclass(frozen=True)
@@ -22,6 +32,15 @@ class StagedLog:
     source: Path
     staged_path: Path
     info: LogFileInfo
+
+
+@dataclass(frozen=True)
+class StagingPruneReport:
+    """Summary of a staging-directory prune operation."""
+
+    scanned_files: int = 0
+    removed_files: int = 0
+    warnings: tuple[str, ...] = ()
 
 
 def _needs_refresh(
@@ -76,6 +95,127 @@ def stage_log(
         shutil.copy2(source_path, target)
 
     return StagedLog(source=source_path, staged_path=target, info=info)
+
+
+def prune_staging_dir(
+    staging_dir: Optional[Path],
+    *,
+    retention_days: int = DEFAULT_STAGING_RETENTION_DAYS,
+    now: datetime | None = None,
+) -> StagingPruneReport:
+    """Delete staged files older than ``retention_days``.
+
+    Pruning is best-effort: per-file metadata/read/delete failures are recorded
+    as warnings and do not raise.
+    """
+
+    if retention_days < 0:
+        raise ValueError("retention_days must be >= 0")
+    if staging_dir is None or not staging_dir.exists():
+        return StagingPruneReport()
+    if not staging_dir.is_dir():
+        warning = f"Skipping prune for non-directory path: {staging_dir}"
+        return StagingPruneReport(warnings=(warning,))
+
+    now_utc = now or datetime.now(timezone.utc)
+    cutoff = now_utc.timestamp() - (retention_days * _SECONDS_PER_DAY)
+    warnings: list[str] = []
+    scanned_files = 0
+    removed_files = 0
+
+    for entry in staging_dir.rglob("*"):
+        if not _is_regular_file(entry, warnings):
+            continue
+        scanned_files += 1
+        timestamp = _entry_timestamp(entry, warnings)
+        if timestamp is None or timestamp >= cutoff:
+            continue
+        try:
+            entry.unlink()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            warnings.append(f"Could not remove {entry}: {exc}")
+            continue
+        removed_files += 1
+
+    return StagingPruneReport(
+        scanned_files=scanned_files,
+        removed_files=removed_files,
+        warnings=tuple(warnings),
+    )
+
+
+def prune_warning_lines(
+    report: StagingPruneReport,
+    *,
+    limit: int = 5,
+) -> list[str]:
+    """Return warning lines for user-facing output with truncation."""
+
+    if limit < 1:
+        raise ValueError("limit must be >= 1")
+    lines = list(report.warnings[:limit])
+    hidden_count = len(report.warnings) - len(lines)
+    if hidden_count > 0:
+        lines.append(
+            f"...plus {hidden_count} additional staging cleanup warning(s)."
+        )
+    return lines
+
+
+def _is_regular_file(path: Path, warnings: list[str]) -> bool:
+    try:
+        return path.is_file()
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        warnings.append(f"Could not inspect {path}: {exc}")
+        return False
+
+
+def _entry_timestamp(path: Path, warnings: list[str]) -> float | None:
+    try:
+        mtime = path.stat().st_mtime
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        warnings.append(f"Could not read metadata for {path}: {exc}")
+        return _timestamp_from_name(path.name)
+    if math.isfinite(mtime) and mtime > 0:
+        return mtime
+    return _timestamp_from_name(path.name)
+
+
+def _timestamp_from_name(filename: str) -> float | None:
+    date_stamp = _date_stamp_from_name(filename)
+    if date_stamp is not None:
+        return date_stamp
+    return _subsearch_stamp_from_name(filename)
+
+
+def _date_stamp_from_name(filename: str) -> float | None:
+    match = _STAMP_NAME_RE.match(filename)
+    if match is None:
+        return None
+    stamp = match.group("stamp")
+    try:
+        parsed = datetime.strptime(stamp, "%Y.%m.%d")
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc).timestamp()
+
+
+def _subsearch_stamp_from_name(filename: str) -> float | None:
+    match = _SUBSEARCH_NAME_RE.match(filename)
+    if match is None:
+        return None
+    stamp = match.group("stamp")
+    try:
+        parsed = datetime.strptime(stamp, "%Y%m%d_%H%M%S")
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc).timestamp()
 
 
 def _extract_single_member_zip(zip_path: Path, target: Path) -> None:

--- a/test/test_staging.py
+++ b/test/test_staging.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+from sm_logtool.staging import prune_staging_dir
+
+
+def test_prune_staging_dir_missing_directory_is_noop(tmp_path):
+    staging_dir = tmp_path / "missing"
+    report = prune_staging_dir(staging_dir)
+
+    assert report.scanned_files == 0
+    assert report.removed_files == 0
+    assert report.warnings == ()
+
+
+def test_prune_staging_dir_removes_only_files_older_than_cutoff(tmp_path):
+    staging_dir = tmp_path / "staging"
+    staging_dir.mkdir()
+    old_file = staging_dir / "2026.02.01-smtpLog.log"
+    new_file = staging_dir / "2026.02.20-smtpLog.log"
+    old_file.write_text("old\n", encoding="utf-8")
+    new_file.write_text("new\n", encoding="utf-8")
+
+    now = datetime(2026, 2, 26, tzinfo=timezone.utc)
+    old_stamp = datetime(2026, 2, 1, tzinfo=timezone.utc).timestamp()
+    new_stamp = datetime(2026, 2, 20, tzinfo=timezone.utc).timestamp()
+    os.utime(old_file, (old_stamp, old_stamp))
+    os.utime(new_file, (new_stamp, new_stamp))
+
+    report = prune_staging_dir(staging_dir, retention_days=14, now=now)
+
+    assert report.scanned_files == 2
+    assert report.removed_files == 1
+    assert report.warnings == ()
+    assert old_file.exists() is False
+    assert new_file.exists() is True
+
+
+def test_prune_staging_dir_continues_when_delete_fails(tmp_path, monkeypatch):
+    staging_dir = tmp_path / "staging"
+    staging_dir.mkdir()
+    stale_file = staging_dir / "2026.02.01-smtpLog.log"
+    stale_file.write_text("stale\n", encoding="utf-8")
+    stale_stamp = datetime(2026, 2, 1, tzinfo=timezone.utc).timestamp()
+    os.utime(stale_file, (stale_stamp, stale_stamp))
+    now = datetime(2026, 2, 26, tzinfo=timezone.utc)
+
+    original_unlink = Path.unlink
+
+    def fake_unlink(self, *args, **kwargs):  # noqa: ANN001
+        if self == stale_file:
+            raise PermissionError("denied")
+        return original_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fake_unlink)
+
+    report = prune_staging_dir(staging_dir, retention_days=14, now=now)
+
+    assert report.removed_files == 0
+    assert stale_file.exists() is True
+    assert len(report.warnings) == 1
+    assert "Could not remove" in report.warnings[0]
+
+
+def test_prune_staging_dir_uses_filename_when_mtime_is_invalid(
+    tmp_path,
+    monkeypatch,
+):
+    staging_dir = tmp_path / "staging"
+    staging_dir.mkdir()
+    stale_file = staging_dir / "2026.02.01-smtpLog.log"
+    stale_file.write_text("stale\n", encoding="utf-8")
+    now = datetime(2026, 2, 26, tzinfo=timezone.utc)
+    current_stamp = now.timestamp()
+    os.utime(stale_file, (current_stamp, current_stamp))
+
+    original_stat = Path.stat
+
+    def fake_stat(self, *args, **kwargs):  # noqa: ANN001
+        if self == stale_file:
+            return SimpleNamespace(st_mtime=float("nan"))
+        return original_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+
+    report = prune_staging_dir(staging_dir, retention_days=14, now=now)
+
+    assert report.removed_files == 1
+    assert stale_file.exists() is False


### PR DESCRIPTION
  # Summary

  Add automatic staging retention cleanup so stale staged artifacts are pruned
  without impacting normal app flow. Cleanup now runs on startup and quit
  (14-day threshold), with best-effort error handling.

  ## Related Issues

  - Closes #87

  ## Type Of Change

  - [ ] Bug fix
  - [x] New feature
  - [x] Refactor/cleanup
  - [x] Documentation update
  - [x] Tests only

  ## What Changed

  - Added 14-day staging cleanup primitives in sm_logtool/staging.py:
  - DEFAULT_STAGING_RETENTION_DAYS
  - StagingPruneReport
  - prune_staging_dir(...)
  - prune_warning_lines(...)
  - Added resilient behavior for edge cases:
  - Missing staging directory is a no-op.
  - Per-file stat/unlink failures are non-fatal and collected as warnings.
  - Invalid/unusable mtime falls back to filename-derived timestamps for known staged patterns.
  - Wired cleanup into CLI search lifecycle:
  - Startup prune before search flow.
  - Wired cleanup into TUI lifecycle (ui.app.run):
  - Startup prune before app launch.
  - Quit prune in a finally block.
  - Updated docs to describe 14-day automatic retention behavior:
  - README.md
  - docs/SEARCH_NOTES.md
  - Added tests for prune behavior and lifecycle hooks:
  - New test/test_staging.py
  - New CLI lifecycle tests in test/test_cli.py
  - New TUI lifecycle tests in test/test_ui_bindings.py

  ## Testing

  List the commands you ran and their results.

  - .venv/bin/python -m ruff check sm_logtool test: pass
  - .venv/bin/python -m mypy sm_logtool: pass
  - python -m pytest -q: pass
  - python -m pytest --maxfail=1 --disable-warnings: pass (186 passed, 1 skipped)
  - python -m unittest discover test: pass (Ran 2 tests, OK)
  - python scripts/check_release_defaults.py: pass

  ## UI Changes (if applicable)

  - [x] No UI changes
  - [ ] UI changed (attach screenshots or terminal captures)

  ## Security And Data Handling

  - [x] I did not include sensitive log data in this PR.
  - [x] I redacted any personal or customer data used in examples/screenshots.

  ## Checklist

  - [x] I used a feature branch (not main).
  - [x] I added or updated tests for behavior changes.
  - [x] I updated docs (README.md, CONTRIBUTING.md, or docs/) as needed.
  - [x] I used present tense in user-facing docs.