### PR TITLE
Fix broken date selection interactions in the TUI log-date picker

### DIFF
--- a/sm_logtool/ui/app.py
+++ b/sm_logtool/ui/app.py
@@ -1459,8 +1459,11 @@ class DateListView(ListView):
         self._update_visual_state()
 
     def _apply_enter(self, index: int) -> None:
-        if not self.selected_indices:
+        if index not in self.selected_indices:
+            # Enter should make the highlighted date usable as the common
+            # single-day path, while Space/click remain available for toggles.
             self.selected_indices = {index}
+            self.anchor_index = index
             self._update_visual_state()
 
         self._post_selection()
@@ -2402,9 +2405,7 @@ class LogBrowser(App):
     ) -> None:  # type: ignore[override]
         if self.step == WizardStep.KIND:
             self._select_kind_item(event.item)
-            return
-        if self.step == WizardStep.DATE:
-            self._select_date_item(event.item)
+        return
 
     def on_date_selection_changed(self, message: DateSelectionChanged) -> None:
         if self.step != WizardStep.DATE:
@@ -2496,21 +2497,6 @@ class LogBrowser(App):
             return
         self.current_kind = item.kind
         self._show_step_date()
-
-    def _select_date_item(self, item: ListItem) -> None:
-        if self.date_list is None or not isinstance(item, DateListItem):
-            return
-        index = self._child_index(self.date_list, item)
-        if index is None:
-            return
-        self.date_list._toggle_index(index)
-        self.date_list.anchor_index = index
-        self.date_list._update_visual_state()
-        self.selected_logs = self.date_list.selected_infos
-        self.post_message(
-            DateSelectionChanged(self.date_list, self.date_list.selected_infos)
-        )
-        self._update_next_button_state()
 
     @staticmethod
     def _child_index(container: ListView, item: ListItem) -> int | None:

--- a/test/test_ui_bindings.py
+++ b/test/test_ui_bindings.py
@@ -29,6 +29,16 @@ def write_sample_logs(root: Path) -> None:
     )
 
 
+def write_sample_logs_for_dates(root: Path, stamps: list[str]) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    for stamp in stamps:
+        log_path = root / f"{stamp}-smtpLog.log"
+        log_path.write_text(
+            "00:00:00 [1.1.1.1][ABC123] Connection initiated\n",
+            encoding="utf-8",
+        )
+
+
 def test_run_prunes_staging_on_startup_and_quit(tmp_path, monkeypatch):
     logs_dir = tmp_path / "logs"
     write_sample_logs(logs_dir)
@@ -1205,6 +1215,62 @@ async def test_plain_question_mark_remains_input_text(tmp_path):
         await pilot.press("?")
         await pilot.pause()
         assert app.search_input.value == "?"
+
+
+@pytest.mark.asyncio
+async def test_date_step_enter_switches_to_highlighted_day(tmp_path):
+    logs_dir = tmp_path / "logs"
+    write_sample_logs_for_dates(
+        logs_dir,
+        ["2024.01.03", "2024.01.02", "2024.01.01"],
+    )
+    app = LogBrowser(logs_dir=logs_dir)
+    async with app.run_test() as pilot:
+        app._refresh_logs()
+        kind, infos = next(iter(app._logs_by_kind.items()))
+        app.current_kind = kind
+        app._show_step_date()
+        await pilot.pause()
+
+        assert [info.path.name for info in app.selected_logs] == [
+            infos[0].path.name
+        ]
+
+        await pilot.press("down", "enter")
+        await pilot.pause()
+
+        assert app.step == WizardStep.SEARCH
+        assert [info.path.name for info in app.selected_logs] == [
+            infos[1].path.name
+        ]
+
+
+@pytest.mark.asyncio
+async def test_date_step_mouse_click_toggles_clicked_day_once(tmp_path):
+    logs_dir = tmp_path / "logs"
+    write_sample_logs_for_dates(
+        logs_dir,
+        ["2024.01.03", "2024.01.02", "2024.01.01"],
+    )
+    app = LogBrowser(logs_dir=logs_dir)
+    async with app.run_test() as pilot:
+        app._refresh_logs()
+        kind, infos = next(iter(app._logs_by_kind.items()))
+        app.current_kind = kind
+        app._show_step_date()
+        await pilot.pause()
+
+        assert app.date_list is not None
+        second_item = list(app.date_list.children)[1]
+
+        await pilot.click(second_item, offset=(1, 0))
+        await pilot.pause()
+
+        assert app.step == WizardStep.DATE
+        assert [info.path.name for info in app.selected_logs] == [
+            infos[0].path.name,
+            infos[1].path.name,
+        ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Summary

Fix the TUI date picker regression so keyboard and mouse selection behave predictably again during log-date selection.

## Related Issues

- Closes #89

## Type Of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/cleanup
- [ ] Documentation update
- [ ] Tests only

## What Changed

- Made `Enter` promote the highlighted unselected date to the active single-date selection before continuing to the search step.
- Removed duplicate date-step selection handling from the app-level `ListView.Selected` path so mouse clicks no longer toggle and then immediately undo themselves.
- Added regression tests for keyboard single-day switching and mouse click selection in the date picker.

## Why

The date step had split interaction paths that no longer agreed with each other. The custom date list managed its own selection state, but the app-level selected handler also toggled date rows, which broke mouse selection. The keyboard path also preserved the default selected day when pressing `Enter` on another highlighted day, which made the common single-day workflow awkward.

## Expected Result

- Clicking a date toggles it exactly once.
- Pressing `Enter` on a highlighted unselected day switches to that single day and continues.
- Multi-select still works through explicit toggle interactions.

## Validation

```bash
.venv/bin/pytest -q test/test_ui_bindings.py -k 'date_step_enter_switches_to_highlighted_day or date_step_mouse_click_toggles_clicked_day_once'
.venv/bin/pytest -q test/test_ui_bindings.py
.venv/bin/python -m ruff check sm_logtool/ui/app.py test/test_ui_bindings.py
.venv/bin/python -m unittest discover test
```

## UI Changes (if applicable)

- [x] No UI changes
- [ ] UI changed (attach screenshots or terminal captures)

## Security And Data Handling

- [x] I did not include sensitive log data in this PR.
- [x] I redacted any personal or customer data used in examples/screenshots.

## Checklist

- [x] I used a feature branch (not `main`).
- [x] I added or updated tests for behavior changes.
- [ ] I updated docs (`README.md`, `CONTRIBUTING.md`, or `docs/`) as needed.
- [x] I used present tense in user-facing docs.
