### PR TITLE
Fix TUI staging status before execution planning

### DIFF
--- a/sm_logtool/ui/app.py
+++ b/sm_logtool/ui/app.py
@@ -2693,7 +2693,9 @@ class LogBrowser(App):
         self._live_target_label = None
         self._live_progress_label = "Search submitted. Preparing logs..."
         self._live_progress_percent = 0
-        self._live_execution_label = "Planning execution mode..."
+        self._live_execution_label = self._initial_live_execution_label(
+            request
+        )
         self._last_execution_label = None
         self._live_match_total = 0
         self._live_match_preview_lines = []
@@ -2704,6 +2706,14 @@ class LogBrowser(App):
         if isinstance(self.output_log, ResultsArea):
             self.output_log.set_log_kind(request.kind)
         self._request_live_output_refresh(force=True)
+
+    def _initial_live_execution_label(
+        self,
+        request: SearchRequest,
+    ) -> str:
+        if request.needs_staging:
+            return "Staging selected logs..."
+        return "Planning execution mode..."
 
     def _build_search_request(self) -> SearchRequest | None:
         if self.staging_dir is None:
@@ -2811,6 +2821,10 @@ class LogBrowser(App):
     ) -> list[Path]:
         if not request.needs_staging:
             return request.source_paths.copy()
+        self.call_from_thread(
+            self._set_live_execution,
+            "Staging selected logs...",
+        )
         assert self.staging_dir is not None
         total = len(request.source_paths)
         targets: list[Path] = []

--- a/test/test_ui_bindings.py
+++ b/test/test_ui_bindings.py
@@ -12,7 +12,13 @@ from sm_logtool.search import get_search_function
 from sm_logtool.search import SmtpSearchResult
 from sm_logtool.result_modes import RESULT_MODE_MATCHING_ROWS
 from sm_logtool.ui import app as ui_app_module
-from sm_logtool.ui.app import LogBrowser, ResultsArea, TopAction, WizardStep
+from sm_logtool.ui.app import (
+    LogBrowser,
+    ResultsArea,
+    SearchRequest,
+    TopAction,
+    WizardStep,
+)
 from sm_logtool.ui.themes import CYBERDARK_THEME_NAME
 from sm_logtool.ui.themes import CYBERNOTDARK_THEME_NAME
 from sm_logtool.ui.theme_importer import load_imported_themes
@@ -721,10 +727,41 @@ async def test_perform_search_notifies_submit_immediately(
         assert "[progress]" in progress_text
         assert "Search submitted. Preparing logs..." in progress_text
         assert "[execution]" in progress_text
-        assert "Planning execution mode..." in progress_text
+        assert "Staging selected logs..." in progress_text
         assert app._search_in_progress is True
         cancel_button = app.wizard.query_one("#cancel-search", Button)
         assert cancel_button.disabled is False
+
+
+@pytest.mark.parametrize(
+    ("needs_staging", "expected_label"),
+    [
+        (True, "Staging selected logs..."),
+        (False, "Planning execution mode..."),
+    ],
+)
+def test_start_live_results_sets_initial_execution_label(
+    tmp_path,
+    needs_staging,
+    expected_label,
+):
+    logs_dir = tmp_path / "logs"
+    write_sample_logs(logs_dir)
+    app = LogBrowser(logs_dir=logs_dir, staging_dir=tmp_path / "staging")
+    request = SearchRequest(
+        kind="smtp",
+        term="Connection",
+        mode="literal",
+        result_mode=RESULT_MODE_MATCHING_ROWS,
+        fuzzy_threshold=0.6,
+        ignore_case=True,
+        source_paths=[logs_dir / "2024.01.01-smtpLog.log"],
+        needs_staging=needs_staging,
+        use_index_cache=needs_staging,
+    )
+
+    assert app._initial_live_execution_label(request) == expected_label
+
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Summary

Update the TUI live results status so staged searches show a staging state before execution planning runs. This removes the misleading `Planning execution mode...` delay while logs are still being prepared.

## Related Issues

- Closes #90
- Related to #90

## Type Of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/cleanup
- [ ] Documentation update
- [ ] Tests only

## What Changed

- set the initial live execution label to `Staging selected logs...` when a search request requires staging
- keep `Planning execution mode...` for requests that do not stage logs before searching
- update the live-status UI test to expect the staging label during staged searches
- add a focused regression test for the initial execution label selection

## Testing

List the commands you ran and their results.

```bash
.venv/bin/pytest -q test/test_ui_bindings.py test/test_search_planning.py
# passed

.venv/bin/ruff check sm_logtool/ui/app.py test/test_ui_bindings.py
# passed
```

## UI Changes (if applicable)

- [ ] No UI changes
- [x] UI changed (attach screenshots or terminal captures)

## Security And Data Handling

- [x] I did not include sensitive log data in this PR.
- [x] I redacted any personal or customer data used in examples/screenshots.

## Checklist

- [x] I used a feature branch (not `main`).
- [x] I added or updated tests for behavior changes.
- [x] I updated docs (`README.md`, `CONTRIBUTING.md`, or `docs/`) as needed.
- [x] I used present tense in user-facing docs.
