### PR TITLE
Prepare 0.9.8 release metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sm-logtool"
-version = "0.9.7"
+version = "0.9.8"
 description = "Interactive TUI and non-interactive CLI helper for exploring SmarterMail logs on Linux servers"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sm_logtool/__init__.py
+++ b/sm_logtool/__init__.py
@@ -4,4 +4,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.9.7"
+__version__ = "0.9.8"


### PR DESCRIPTION
# Summary

Prepare the `0.9.8` release metadata so the current `main` changes can be published as a GitHub release and PyPI package.

## Related Issues

- Related to #87
- Related to #89
- Related to #90

## Type Of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/cleanup
- [ ] Documentation update
- [ ] Tests only

## What Changed

- bumped the package version from `0.9.7` to `0.9.8` in the canonical metadata files
- validated the release candidate with the same quality gates used by the publish workflow
- tagged `v0.9.8` so release publication can target the prepared version metadata

## Testing

List the commands you ran and their results.

```bash
.venv/bin/python -m ruff check .
# passed

.venv/bin/python -m mypy sm_logtool
# passed

.venv/bin/python -m pytest -q
# passed

.venv/bin/python -m unittest discover test
# passed

.venv/bin/python scripts/check_release_defaults.py
# passed
```

## UI Changes (if applicable)

- [x] No UI changes
- [ ] UI changed (attach screenshots or terminal captures)

## Security And Data Handling

- [x] I did not include sensitive log data in this PR.
- [x] I redacted any personal or customer data used in examples/screenshots.

## Checklist

- [x] I used a feature branch (not `main`).
- [x] I added or updated tests for behavior changes.
- [x] I updated docs (`README.md`, `CONTRIBUTING.md`, or `docs/`) as needed.
- [x] I used present tense in user-facing docs.
