### PR TITLE
Fix staging prune test under Python 3.12

### DIFF
--- a/test/test_staging.py
+++ b/test/test_staging.py
@@ -83,7 +83,11 @@ def test_prune_staging_dir_uses_filename_when_mtime_is_invalid(
 
     def fake_stat(self, *args, **kwargs):  # noqa: ANN001
         if self == stale_file:
-            return SimpleNamespace(st_mtime=float("nan"))
+            stat_result = original_stat(self, *args, **kwargs)
+            return SimpleNamespace(
+                st_mtime=float("nan"),
+                st_mode=stat_result.st_mode,
+            )
         return original_stat(self, *args, **kwargs)
 
     monkeypatch.setattr(Path, "stat", fake_stat)


### PR DESCRIPTION
# Summary

Fix the staging prune filename-fallback test so it still exercises the intended behavior under Python 3.12. The publish workflow failed because the mocked `Path.stat()` result no longer satisfied `Path.is_file()` on newer Python.

## Related Issues

- Related to #87
- Related to #90

## Type Of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/cleanup
- [ ] Documentation update
- [ ] Tests only

## What Changed

- updated the mocked `Path.stat()` result in `test/test_staging.py` to include `st_mode` from the real file stat result
- preserved the test intent of forcing an invalid `st_mtime` so prune falls back to the filename timestamp
- re-ran the release quality gates locally to confirm the publish workflow failure is resolved

## Testing

List the commands you ran and their results.

```bash
.venv/bin/pytest -q test/test_staging.py
# passed

.venv/bin/python -m pytest -q
# passed

.venv/bin/python -m unittest discover test
# passed

.venv/bin/python -m ruff check .
# passed

.venv/bin/python -m mypy sm_logtool
# passed

.venv/bin/python scripts/check_release_defaults.py
# passed
```

## UI Changes (if applicable)

- [x] No UI changes
- [ ] UI changed (attach screenshots or terminal captures)

## Security And Data Handling

- [x] I did not include sensitive log data in this PR.
- [x] I redacted any personal or customer data used in examples/screenshots.

## Checklist

- [x] I used a feature branch (not `main`).
- [x] I added or updated tests for behavior changes.
- [ ] I updated docs (`README.md`, `CONTRIBUTING.md`, or `docs/`) as needed.
- [x] I used present tense in user-facing docs.
