### PR TITLE
Update GitHub Actions to current majors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -43,7 +43,7 @@ jobs:
           python -m twine check dist/*
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -58,7 +58,7 @@ jobs:
       id-token: write
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/standards.yml
+++ b/.github/workflows/standards.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
# Summary

Update the repository workflow action pins to current major versions so GitHub Actions stops warning about deprecated Node.js 20 runtimes on the first-party actions we use.

## Related Issues

- Related to #90
- Related to #94

## Type Of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor/cleanup
- [ ] Documentation update
- [ ] Tests only

## What Changed

- updated `actions/checkout` from `v4` to `v6` in the test, publish, and standards workflows
- updated `actions/setup-python` from `v5` to `v6` in the test, publish, and standards workflows
- updated `actions/upload-artifact` from `v4` to `v7` in the publish workflow
- updated `actions/download-artifact` from `v4` to `v8` in the publish workflow
- kept `pypa/gh-action-pypi-publish@release/v1` unchanged because that remains the upstream-recommended major alias

## Testing

List the commands you ran and their results.

```bash
.venv/bin/python -c "from pathlib import Path; import yaml; [yaml.safe_load(path.read_text()) for path in Path('.github/workflows').glob('*.yml')]; print('YAML OK')"
# passed
```

## UI Changes (if applicable)

- [x] No UI changes
- [ ] UI changed (attach screenshots or terminal captures)

## Security And Data Handling

- [x] I did not include sensitive log data in this PR.
- [x] I redacted any personal or customer data used in examples/screenshots.

## Checklist

- [x] I used a feature branch (not `main`).
- [ ] I added or updated tests for behavior changes.
- [ ] I updated docs (`README.md`, `CONTRIBUTING.md`, or `docs/`) as needed.
- [x] I used present tense in user-facing docs.
