### PR TITLE
Clarify Step 2 default date selection

### DIFF
--- a/sm_logtool/ui/app.py
+++ b/sm_logtool/ui/app.py
@@ -2041,8 +2041,12 @@ class LogBrowser(App):
     def _show_step_date(self) -> None:
         self.step = WizardStep.DATE
         self._clear_wizard()
-        step_text = "Step 2: Select one or more log dates"
-        self.wizard.mount(Static(step_text, classes="instruction"))
+        self.wizard.mount(
+            Static(
+                self._date_step_heading_text(),
+                classes="instruction",
+            )
+        )
         instructions = Static(
             "Use arrow keys or the mouse to highlight a date. Press Space or "
             "click to toggle it.\nPress Enter (or Next) when you are ready "
@@ -2082,6 +2086,15 @@ class LogBrowser(App):
         self._update_next_button_state()
         self.date_list.focus()
         self._refresh_footer_bindings()
+
+    def _date_step_heading_text(self) -> Text:
+        """Return the Step 2 heading with a preferred wrap before the note."""
+
+        primary = "Step 2: Select one or more log dates"
+        note = "(Today is selected by default, deselect if unwanted)"
+        # Keep the primary heading together and prefer wrapping before the
+        # explanatory note when the available width is tight.
+        return Text(primary.replace(" ", "\u00a0") + "\u200b " + note)
 
     def _show_step_search(self) -> None:
         self.step = WizardStep.SEARCH

--- a/test/test_ui_bindings.py
+++ b/test/test_ui_bindings.py
@@ -1282,6 +1282,22 @@ async def test_date_step_enter_switches_to_highlighted_day(tmp_path):
         ]
 
 
+def test_date_step_heading_prefers_wrap_before_default_note(tmp_path):
+    logs_dir = tmp_path / "logs"
+    write_sample_logs(logs_dir)
+    app = LogBrowser(logs_dir=logs_dir)
+
+    heading = app._date_step_heading_text().plain
+
+    assert (
+        heading.replace("\u00a0", " ").replace("\u200b", "")
+        == "Step 2: Select one or more log dates "
+        "(Today is selected by default, deselect if unwanted)"
+    )
+    assert "\u200b " in heading
+    assert "\u00a0" in heading
+
+
 @pytest.mark.asyncio
 async def test_date_step_mouse_click_toggles_clicked_day_once(tmp_path):
     logs_dir = tmp_path / "logs"


### PR DESCRIPTION
# Summary

Clarify the Step 2 date-selection heading so the UI tells users that today is selected by default, and prefer wrapping before that explanatory note when the screen is narrow.

## Related Issues

- Closes #96
- Related to #89

## Type Of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/cleanup
- [ ] Documentation update
- [ ] Tests only

## What Changed

- updated the Step 2 heading text to include the default-selection note
- rendered the heading through a helper so the preferred wrap point sits before the parenthetical note
- added a UI regression test that checks the visible text and wrap markers used for the heading

## Testing

List the commands you ran and their results.

```bash
.venv/bin/pytest -q test/test_ui_bindings.py
# passed

.venv/bin/ruff check sm_logtool/ui/app.py test/test_ui_bindings.py
# passed
```

## UI Changes (if applicable)

- [ ] No UI changes
- [x] UI changed (attach screenshots or terminal captures)

## Security And Data Handling

- [x] I did not include sensitive log data in this PR.
- [x] I redacted any personal or customer data used in examples/screenshots.

## Checklist

- [x] I used a feature branch (not `main`).
- [x] I added or updated tests for behavior changes.
- [ ] I updated docs (`README.md`, `CONTRIBUTING.md`, or `docs/`) as needed.
- [x] I used present tense in user-facing docs.
