### PR TITLE
Prepare docs and metadata for 1.0.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,27 +67,27 @@ Add cases under `test/test_*.py` with descriptive names. Lean on fixtures such a
 - Use `docs/RELEASE_NOTES_TEMPLATE.md` as the standard format when drafting
   release notes for publishing.
 
-## Standards Audit Backlog (2026-02-26)
-- [ ] [Issue #61](https://github.com/T313C0mun1s7/sm-logtool/issues/61):
+## Standards Audit Status (Completed 2026-04-23)
+- [x] [Issue #61](https://github.com/T313C0mun1s7/sm-logtool/issues/61):
   Ensure unittest discovery runs the real test suite.
-- [ ] [Issue #62](https://github.com/T313C0mun1s7/sm-logtool/issues/62):
+- [x] [Issue #62](https://github.com/T313C0mun1s7/sm-logtool/issues/62):
   Refactor `sm_logtool/ui/app.py` into smaller units and reduce nesting.
-- [ ] [Issue #63](https://github.com/T313C0mun1s7/sm-logtool/issues/63):
+- [x] [Issue #63](https://github.com/T313C0mun1s7/sm-logtool/issues/63):
   Refactor CLI parser/search orchestration for maintainability.
-- [ ] [Issue #64](https://github.com/T313C0mun1s7/sm-logtool/issues/64):
+- [x] [Issue #64](https://github.com/T313C0mun1s7/sm-logtool/issues/64):
   Close public API docstring gaps and add enforcement.
-- [ ] [Issue #65](https://github.com/T313C0mun1s7/sm-logtool/issues/65):
+- [x] [Issue #65](https://github.com/T313C0mun1s7/sm-logtool/issues/65):
   Enforce the 79-character line-length policy.
-- [ ] [Issue #66](https://github.com/T313C0mun1s7/sm-logtool/issues/66):
+- [x] [Issue #66](https://github.com/T313C0mun1s7/sm-logtool/issues/66):
   Remove tracked environment-specific config and document sample config
   workflow.
-- [ ] [Issue #67](https://github.com/T313C0mun1s7/sm-logtool/issues/67):
+- [x] [Issue #67](https://github.com/T313C0mun1s7/sm-logtool/issues/67):
   Optimize live search preview rendering to reduce redraw churn.
-- [ ] [Issue #68](https://github.com/T313C0mun1s7/sm-logtool/issues/68):
+- [x] [Issue #68](https://github.com/T313C0mun1s7/sm-logtool/issues/68):
   Deduplicate ungrouped log-kind mapping across modules.
-- [ ] [Issue #69](https://github.com/T313C0mun1s7/sm-logtool/issues/69):
+- [x] [Issue #69](https://github.com/T313C0mun1s7/sm-logtool/issues/69):
   Move pytest tooling out of runtime dependencies.
-- [ ] [Issue #70](https://github.com/T313C0mun1s7/sm-logtool/issues/70):
+- [x] [Issue #70](https://github.com/T313C0mun1s7/sm-logtool/issues/70):
   Add standards-compliance checks to CI.
 
 ## Security & Configuration Tips
@@ -101,7 +101,7 @@ The default runtime config path is per-user: `~/.config/sm-logtool/config.yaml`.
 Theme import sources and converted themes are also per-user:
 `~/.config/sm-logtool/theme-sources` and `~/.config/sm-logtool/themes`.
 
-## Upcoming Work
+## Delivered Work
 - [x] Expand the search pipeline to cover additional SmarterMail log kinds and grouping rules.
 - [x] Add syntax highlighting for supported log kinds in the TUI view.
 - [x] Add syntax highlighting for supported log kinds in the CLI view.
@@ -131,16 +131,22 @@ Theme import sources and converted themes are also per-user:
 
 
 ## Current State Notes
-- [x] Toggle-only date selection works with arrows, `Space`, and `Enter`.
+- [x] Date selection supports mouse toggles, `Space`, and `Enter` as the
+  common single-day continue path; today is selected by default and the Step
+  2 heading now says so.
 - [x] Core actions (`Menu`, `Quit`, `Reset`) stay visible in the top action
   strip, while step-specific search shortcuts remain in the footer.
 - [x] Search results display one log line per row after formatting updates.
+- [x] Staged searches show a staging status before execution planning instead
+  of sitting on a misleading planning label.
 - [x] `sm-logtool themes` provides a visual Theme Studio with live Browse-style
   preview and ANSI-256-aware mapping profiles.
 - [x] Converted themes load automatically from the per-user theme store and
   apply to both chrome and syntax results.
 - [x] Theme Studio supports manual element remapping and enforces distinct
   selection states for usable date-list highlighting.
+- [x] GitHub Actions workflows use current action majors for checkout, Python
+  setup, and artifact transfer.
 
 ## Issue #21 Implementation Notes (Completed)
 - Baseline measurements were captured against real staged logs before tuning.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ sm-logtool browse --logs-dir /var/lib/smartermail/Logs
 Wizard flow:
 
 1. Choose log kind.
-2. Select one or more log dates.
+2. Select one or more log dates. Today is selected by default; deselect it
+   if unwanted.
 3. Enter search term and choose search mode
    (`Literal`/`Wildcard`/`Regex`/`Fuzzy`) plus result mode
    (`Show all related traffic`/`Only matching rows`).
@@ -176,8 +177,10 @@ Clipboard note:
 Date selection shortcuts:
 
 - Arrow keys to move
+- Click to toggle a date
 - `Space` to toggle a date
-- `Enter` to continue
+- `Enter` to select the highlighted date and continue
+- Today is selected by default when the date step opens
 
 ### Run console search
 

--- a/docs/SEARCH_NOTES.md
+++ b/docs/SEARCH_NOTES.md
@@ -55,6 +55,7 @@ Search handlers currently exist for:
   - percent complete,
   - an inline progress bar,
   - current phase/detail text,
+  - an explicit staging phase before execution planning for staged searches,
   - execution mode notes (serial/parallel/fallback),
   - live match preview while active targets are scanning.
 - Search results stream into the results view as completed targets return.
@@ -70,7 +71,10 @@ Search handlers currently exist for:
 ### TUI behavior
 
 - Wizard flow: log kind -> date selection -> search -> results.
-- Date selection supports keyboard and mouse toggling.
+- Date selection starts with today selected by default when available.
+- Date selection supports mouse toggles, `Space` toggles, and `Enter` as the
+  common single-day continue path.
+- The Step 2 heading now tells users that today is selected by default.
 - Search step includes explicit mode switching
   (`Literal`/`Wildcard`/`Regex`/`Fuzzy`).
 - Search step includes explicit result-mode switching
@@ -117,33 +121,33 @@ Search handlers currently exist for:
 - [x] Improve large-log performance and responsiveness (progress feedback,
   background work, reduced memory footprint, index reuse).
 
-## Audit Backlog (2026-02-26)
+## Standards Audit Status (Completed 2026-04-23)
 
 Cross-project tracking items from the standards audit:
 
-- [ ] [Issue #61](https://github.com/T313C0mun1s7/sm-logtool/issues/61):
+- [x] [Issue #61](https://github.com/T313C0mun1s7/sm-logtool/issues/61):
   ensure unittest discovery runs the real test suite.
-- [ ] [Issue #62](https://github.com/T313C0mun1s7/sm-logtool/issues/62):
+- [x] [Issue #62](https://github.com/T313C0mun1s7/sm-logtool/issues/62):
   refactor `sm_logtool/ui/app.py` into smaller units and reduce nesting.
-- [ ] [Issue #63](https://github.com/T313C0mun1s7/sm-logtool/issues/63):
+- [x] [Issue #63](https://github.com/T313C0mun1s7/sm-logtool/issues/63):
   refactor CLI parser/search orchestration for maintainability.
-- [ ] [Issue #64](https://github.com/T313C0mun1s7/sm-logtool/issues/64):
+- [x] [Issue #64](https://github.com/T313C0mun1s7/sm-logtool/issues/64):
   close public API docstring gaps and add enforcement.
-- [ ] [Issue #65](https://github.com/T313C0mun1s7/sm-logtool/issues/65):
+- [x] [Issue #65](https://github.com/T313C0mun1s7/sm-logtool/issues/65):
   enforce the 79-character line-length policy.
-- [ ] [Issue #66](https://github.com/T313C0mun1s7/sm-logtool/issues/66):
+- [x] [Issue #66](https://github.com/T313C0mun1s7/sm-logtool/issues/66):
   remove tracked environment-specific config and document sample config
   workflow.
 
 Search-focused optimization and structure items:
 
-- [ ] [Issue #67](https://github.com/T313C0mun1s7/sm-logtool/issues/67):
+- [x] [Issue #67](https://github.com/T313C0mun1s7/sm-logtool/issues/67):
   optimize live search preview rendering to reduce redraw churn.
-- [ ] [Issue #68](https://github.com/T313C0mun1s7/sm-logtool/issues/68):
+- [x] [Issue #68](https://github.com/T313C0mun1s7/sm-logtool/issues/68):
   deduplicate ungrouped log-kind mapping across modules.
-- [ ] [Issue #69](https://github.com/T313C0mun1s7/sm-logtool/issues/69):
+- [x] [Issue #69](https://github.com/T313C0mun1s7/sm-logtool/issues/69):
   move pytest tooling out of runtime dependencies.
-- [ ] [Issue #70](https://github.com/T313C0mun1s7/sm-logtool/issues/70):
+- [x] [Issue #70](https://github.com/T313C0mun1s7/sm-logtool/issues/70):
   add standards-compliance checks to CI.
 
 ## Notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sm-logtool"
-version = "0.9.8"
+version = "1.0.0"
 description = "Interactive TUI and non-interactive CLI helper for exploring SmarterMail logs on Linux servers"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sm_logtool/__init__.py
+++ b/sm_logtool/__init__.py
@@ -4,4 +4,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.9.8"
+__version__ = "1.0.0"


### PR DESCRIPTION
# Summary

Prepare the repository for the `1.0.0` release by aligning user-facing docs with the current product behavior and updating the package version metadata.

## Related Issues

- Related to #96
- Related to #94

## Type Of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor/cleanup
- [x] Documentation update
- [ ] Tests only

## What Changed

- bumped package metadata from `0.9.8` to `1.0.0`
- updated `README.md` so the Step 2 date-selection guidance matches the current default-selection behavior and controls
- updated `AGENTS.md` and `docs/SEARCH_NOTES.md` so they reflect the current completed standards-audit state instead of stale backlog markers
- refreshed current-state notes to mention the staged-search status improvement, current date-step behavior, and updated GitHub Actions workflow state

## Testing

List the commands you ran and their results.

```bash
.venv/bin/python -m ruff check .
# passed

.venv/bin/python -m mypy sm_logtool
# passed

.venv/bin/python -m pytest -q
# passed

.venv/bin/python -m unittest discover test
# passed

.venv/bin/python scripts/check_release_defaults.py
# passed
```

## UI Changes (if applicable)

- [x] No UI changes
- [ ] UI changed (attach screenshots or terminal captures)

## Security And Data Handling

- [x] I did not include sensitive log data in this PR.
- [x] I redacted any personal or customer data used in examples/screenshots.

## Checklist

- [x] I used a feature branch (not `main`).
- [ ] I added or updated tests for behavior changes.
- [x] I updated docs (`README.md`, `CONTRIBUTING.md`, or `docs/`) as needed.
- [x] I used present tense in user-facing docs.
