### PR TITLE
Prepare v1.0.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sm-logtool"
-version = "1.0.0"
+version = "1.0.1"
 description = "Interactive TUI and non-interactive CLI helper for exploring SmarterMail logs on Linux servers"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sm_logtool/__init__.py
+++ b/sm_logtool/__init__.py
@@ -4,4 +4,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"


### PR DESCRIPTION
## Summary
Prepare the package metadata for publishing sm-logtool v1.0.1.

## What changed
- Bump pyproject.toml project version from 1.0.0 to 1.0.1.
- Bump sm_logtool.__version__ from 1.0.0 to 1.0.1.
- Confirm no remaining tracked 1.0.0 references exist.

## Why
This aligns tracked package version metadata before the v1.0.1 publish process.

## Expected result
Builds and --version metadata report 1.0.1 once this release-prep branch is merged.

## Scope
Release preparation only. Merge after PR #100 if the SMTP-to-Delivery lookup should be included in v1.0.1.

## Validation
- rg -n "1\.0\.0|1\.0\.1" .
- .venv/bin/python -m pytest -q test/test_line_length_policy.py test/test_public_docstrings.py test/test_cli.py::test_main_version_flag_prints_version_and_exits_zero
- .venv/bin/python scripts/check_release_defaults.py
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mypy sm_logtool
- .venv/bin/python -m pytest -q
- .venv/bin/python -m unittest discover test
