### PR TITLE
Fix delivery lookup link interactions

### DIFF
--- a/sm_logtool/ui/app.py
+++ b/sm_logtool/ui/app.py
@@ -582,6 +582,18 @@ class ResultsArea(TextArea):
         self.register_theme(RESULTS_THEME_DEFAULT)
         self.set_visual_theme()
 
+    def _end_mouse_interaction(self) -> None:
+        end_selection = getattr(self, "_end_mouse_selection", None)
+        if callable(end_selection):
+            try:
+                end_selection()
+            except Exception:
+                pass
+        try:
+            self.release_mouse()
+        except Exception:
+            pass
+
     def set_log_kind(self, log_kind: str | None) -> None:
         self._log_kind = log_kind or ""
         self._build_highlight_map()
@@ -629,16 +641,7 @@ class ResultsArea(TextArea):
     ) -> None:  # pragma: no cover - UI behaviour
         if getattr(event, "button", None) == 3:
             selection = self.selected_text or None
-            end_selection = getattr(self, "_end_mouse_selection", None)
-            if callable(end_selection):
-                try:
-                    end_selection()
-                except Exception:
-                    pass
-            try:
-                self.release_mouse()
-            except Exception:
-                pass
+            self._end_mouse_interaction()
             region = getattr(self, "region", None)
             if region is not None:
                 screen_x = int(region.x + event.x)
@@ -665,6 +668,8 @@ class ResultsArea(TextArea):
             app = getattr(self, "app", None)
             open_lookup = getattr(app, "_open_delivery_lookup", None)
             if open_lookup is not None:
+                self._end_mouse_interaction()
+                self._hover_delivery_lookup_row = None
                 open_lookup(link)
                 event.stop()
                 return
@@ -675,11 +680,19 @@ class ResultsArea(TextArea):
         event: events.MouseMove,
     ) -> None:  # pragma: no cover - UI behaviour
         previous = self._hover_delivery_lookup_row
-        link = self._delivery_lookup_link_at_event(event)
+        selecting = bool(getattr(self, "_selecting", False))
+        link = (
+            None
+            if selecting
+            else self._delivery_lookup_link_at_event(event)
+        )
         self._hover_delivery_lookup_row = link.row if link else None
         if previous != self._hover_delivery_lookup_row:
             self._build_highlight_map()
             self.refresh()
+        if link is not None:
+            event.stop()
+            return
         await super()._on_mouse_move(event)
 
     def _delivery_lookup_link_at_event(
@@ -4000,13 +4013,21 @@ class LogBrowser(App):
             return None
         if result_mode != RESULT_MODE_RELATED_TRAFFIC:
             return None
-        target_date = parse_log_filename(target).stamp
-        if target_date is None:
-            return None
         spool_root = _accepted_delivery_spool_root(lines)
         if spool_root is None:
             return None
+        target_date = parse_log_filename(target).stamp
+        if target_date is None:
+            target_date = self._delivery_lookup_date_for_root(spool_root)
+        if target_date is None:
+            return None
         return (spool_root, target_date)
+
+    def _delivery_lookup_date_for_root(self, spool_root: str) -> date | None:
+        for link in self.last_delivery_lookup_links:
+            if link.spool_root == spool_root:
+                return link.target_date
+        return None
 
     def _indexed_delivery_lookup_links(
         self,

--- a/test/test_ui_bindings.py
+++ b/test/test_ui_bindings.py
@@ -833,6 +833,81 @@ def test_smtp_result_view_adds_delivery_lookup_link(tmp_path):
     ]
 
 
+def test_smtp_subsearch_result_view_reuses_prior_delivery_link_date(
+    tmp_path,
+):
+    logs_dir = tmp_path / "logs"
+    write_sample_logs(logs_dir)
+    subsearch_path = tmp_path / "staging" / "subsearch_01.log"
+    app = LogBrowser(logs_dir=logs_dir, staging_dir=tmp_path / "staging")
+    app.last_delivery_lookup_links = [
+        _DeliveryLookupLink(8, "67518204", date(2024, 1, 1)),
+    ]
+    result = SmtpSearchResult(
+        term="other@example.net",
+        log_path=subsearch_path,
+        conversations=[
+            Conversation(
+                message_id="10059869",
+                first_line_number=1,
+                lines=[
+                    (
+                        "00:05:47.504 [100.110.209.55] [10059869] "
+                        "Successfully wrote to the HDR file. "
+                        "(/var/lib/smartermail/Spool/SubSpool8/"
+                        "67518204.hdr)"
+                    ),
+                    (
+                        "00:05:47.504 [100.110.209.55] [10059869] "
+                        "Data transfer succeeded, writing mail to "
+                        "67518204.eml"
+                    ),
+                ],
+            )
+        ],
+        total_lines=2,
+        orphan_matches=[],
+    )
+
+    rendered = app._render_result_view(
+        [result],
+        [subsearch_path],
+        "smtp",
+        "related",
+    )
+
+    assert DELIVERY_LOOKUP_LINK_TEXT in rendered.lines
+    assert rendered.delivery_lookup_links == [
+        _DeliveryLookupLink(
+            rendered.lines.index(DELIVERY_LOOKUP_LINK_TEXT),
+            "67518204",
+            date(2024, 1, 1),
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_results_area_end_mouse_interaction_releases_capture(tmp_path):
+    logs_dir = tmp_path / "logs"
+    write_sample_logs(logs_dir)
+    app = LogBrowser(logs_dir=logs_dir)
+    async with app.run_test() as pilot:
+        app._show_step_results()
+        await pilot.pause()
+        area = app.wizard.query_one(ResultsArea)
+        calls: list[str] = []
+        area._end_mouse_selection = (  # type: ignore[attr-defined]
+            lambda: calls.append("end")
+        )
+        area.release_mouse = (  # type: ignore[method-assign]
+            lambda: calls.append("release")
+        )
+
+        area._end_mouse_interaction()
+
+        assert calls == ["end", "release"]
+
+
 def test_delivery_lookup_request_targets_same_day_delivery_log(tmp_path):
     logs_dir = tmp_path / "logs"
     logs_dir.mkdir()


### PR DESCRIPTION
## Summary
Fix two regressions in the SMTP-to-Delivery lookup workflow added in v1.0.1.

## What changed
- End TextArea mouse selection and release mouse capture before opening a Delivery lookup from a result link.
- Prevent hover-only movement over Delivery lookup links from being handled as TextArea selection movement.
- Reuse prior SMTP result spool-root/date metadata when rendering SMTP sub-search results from staged subsearch files.
- Add regression coverage for mouse interaction cleanup and Delivery links in SMTP sub-search results.

## Why
Testing found that clicking a Delivery lookup link could leave the results widget in a stale mouse-capture/selection state, making further mouse interaction appear frozen. Testing also found that SMTP sub-search results lost Delivery lookup links because staged sub-search filenames do not preserve the original SMTP log date.

## Expected result
Users can click a Delivery lookup link, continue using mouse hover/click behavior afterward, and see Delivery lookup links in SMTP sub-search results as well as top-level SMTP results.

## Scope
Hotfix for v1.0.1 Delivery lookup behavior.

## Validation
- .venv/bin/python -m pytest -q
- .venv/bin/python -m unittest discover test
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mypy sm_logtool
