### PR TITLE
Prevent stale results mouse capture

### DIFF
--- a/sm_logtool/ui/app.py
+++ b/sm_logtool/ui/app.py
@@ -639,7 +639,8 @@ class ResultsArea(TextArea):
         self,
         event: events.MouseDown,
     ) -> None:  # pragma: no cover - UI behaviour
-        if getattr(event, "button", None) == 3:
+        button = getattr(event, "button", _MOUSE_LEFT_BUTTON)
+        if button == _MOUSE_RIGHT_BUTTON:
             selection = self.selected_text or None
             self._end_mouse_interaction()
             region = getattr(self, "region", None)
@@ -663,6 +664,10 @@ class ResultsArea(TextArea):
             self.call_after_refresh(_open_menu)
             event.stop()
             return
+        if button != _MOUSE_LEFT_BUTTON:
+            self._end_mouse_interaction()
+            event.stop()
+            return
         link = self._delivery_lookup_link_at_event(event)
         if link is not None:
             app = getattr(self, "app", None)
@@ -674,6 +679,20 @@ class ResultsArea(TextArea):
                 event.stop()
                 return
         await super()._on_mouse_down(event)
+
+    async def _on_mouse_up(
+        self,
+        event: events.MouseUp,
+    ) -> None:  # pragma: no cover - UI behaviour
+        try:
+            await super()._on_mouse_up(event)
+        finally:
+            self._end_mouse_interaction()
+
+    def on_unmount(self) -> None:
+        """Release mouse capture if results are redrawn during interaction."""
+
+        self._end_mouse_interaction()
 
     async def _on_mouse_move(
         self,
@@ -990,6 +1009,8 @@ _LIVE_OUTPUT_REFRESH_SECONDS = 0.1
 _BACK_NAVIGATION_GUARD_SECONDS = 0.35
 _LIVE_PROGRESS_BAR_WIDTH = 24
 _OSC52_MAX_TEXT_BYTES = 75000
+_MOUSE_LEFT_BUTTON = 1
+_MOUSE_RIGHT_BUTTON = 3
 DELIVERY_LOOKUP_LINK_TEXT = "Find this message in the Delivery Log"
 _DELIVERY_SPOOL_FILE = re.compile(r"\b(?P<root>\d+)\.(?:hdr|eml)\b")
 _DELIVERY_ACCEPTANCE_MARKERS = (
@@ -2757,6 +2778,8 @@ class LogBrowser(App):
                 break
 
     def _clear_wizard(self) -> None:
+        if isinstance(self.output_log, ResultsArea):
+            self.output_log._end_mouse_interaction()
         if hasattr(self, 'wizard'):
             for child in list(self.wizard.children):
                 child.remove()

--- a/test/test_ui_bindings.py
+++ b/test/test_ui_bindings.py
@@ -908,6 +908,54 @@ async def test_results_area_end_mouse_interaction_releases_capture(tmp_path):
         assert calls == ["end", "release"]
 
 
+@pytest.mark.asyncio
+async def test_results_area_ignores_middle_mouse_down(tmp_path):
+    logs_dir = tmp_path / "logs"
+    write_sample_logs(logs_dir)
+    app = LogBrowser(logs_dir=logs_dir)
+
+    class Event:
+        button = 2
+        stopped = False
+
+        def stop(self) -> None:
+            self.stopped = True
+
+    async with app.run_test() as pilot:
+        app._show_step_results()
+        await pilot.pause()
+        area = app.wizard.query_one(ResultsArea)
+        calls: list[str] = []
+        area._end_mouse_interaction = (  # type: ignore[method-assign]
+            lambda: calls.append("end")
+        )
+        event = Event()
+
+        await area._on_mouse_down(event)  # type: ignore[arg-type]
+
+        assert calls == ["end"]
+        assert event.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_clear_wizard_releases_results_mouse_capture(tmp_path):
+    logs_dir = tmp_path / "logs"
+    write_sample_logs(logs_dir)
+    app = LogBrowser(logs_dir=logs_dir)
+    async with app.run_test() as pilot:
+        app._show_step_results()
+        await pilot.pause()
+        area = app.wizard.query_one(ResultsArea)
+        calls: list[str] = []
+        area._end_mouse_interaction = (  # type: ignore[method-assign]
+            lambda: calls.append("end")
+        )
+
+        app._clear_wizard()
+
+        assert calls == ["end"]
+
+
 def test_delivery_lookup_request_targets_same_day_delivery_log(tmp_path):
     logs_dir = tmp_path / "logs"
     logs_dir.mkdir()


### PR DESCRIPTION
## Summary
Fix the remaining mouse interaction lockup in TUI results after Delivery lookup navigation and middle-click input.

## What changed
- Ignore non-left/non-right mouse-downs in ResultsArea before TextArea can capture the mouse.
- Release ResultsArea mouse capture on mouse-up, wizard redraw/clear, and unmount.
- Preserve existing right-click context menu behavior.
- Add regression coverage for middle-click suppression and result-redraw mouse cleanup.

## Why
Production testing showed the mouse could still become unusable after opening Delivery lookup results, and middle-clicking/pressing the scroll wheel in Delivery results could trigger the same issue. This points to stale TextArea mouse capture surviving result redraws or unsupported mouse buttons.

## Expected result
Users can click Delivery lookup links, scroll or press the mouse wheel in results, and continue using mouse hover/click behavior without the TUI becoming temporarily unresponsive.

## Scope
Hotfix follow-up for the v1.0.1/v1.0.2 SMTP-to-Delivery lookup workflow.

## Validation
- .venv/bin/python -m pytest -q
- .venv/bin/python -m unittest discover test
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mypy sm_logtool
