### PR TITLE
Activate delivery lookup links on mouse up

### DIFF
--- a/sm_logtool/ui/app.py
+++ b/sm_logtool/ui/app.py
@@ -567,6 +567,7 @@ class ResultsArea(TextArea):
         self._log_kind = log_kind or ""
         self._delivery_lookup_links: dict[int, _DeliveryLookupLink] = {}
         self._hover_delivery_lookup_row: int | None = None
+        self._pressed_delivery_lookup_link: _DeliveryLookupLink | None = None
         super().__init__(
             text="",
             language=None,
@@ -608,6 +609,12 @@ class ResultsArea(TextArea):
         self._delivery_lookup_links = {link.row: link for link in links}
         if self._hover_delivery_lookup_row not in self._delivery_lookup_links:
             self._hover_delivery_lookup_row = None
+        if (
+            self._pressed_delivery_lookup_link is not None
+            and self._pressed_delivery_lookup_link.row
+            not in self._delivery_lookup_links
+        ):
+            self._pressed_delivery_lookup_link = None
         self._build_highlight_map()
         self.refresh()
 
@@ -670,20 +677,26 @@ class ResultsArea(TextArea):
             return
         link = self._delivery_lookup_link_at_event(event)
         if link is not None:
-            app = getattr(self, "app", None)
-            open_lookup = getattr(app, "_open_delivery_lookup", None)
-            if open_lookup is not None:
-                self._end_mouse_interaction()
-                self._hover_delivery_lookup_row = None
-                open_lookup(link)
-                event.stop()
-                return
+            self._pressed_delivery_lookup_link = link
+            self._end_mouse_interaction()
+            event.stop()
+            return
         await super()._on_mouse_down(event)
 
     async def _on_mouse_up(
         self,
         event: events.MouseUp,
     ) -> None:  # pragma: no cover - UI behaviour
+        pending_link = self._pressed_delivery_lookup_link
+        if pending_link is not None:
+            self._pressed_delivery_lookup_link = None
+            self._end_mouse_interaction()
+            released_link = self._delivery_lookup_link_at_event(event)
+            if released_link == pending_link:
+                self._hover_delivery_lookup_row = None
+                self._open_delivery_lookup(released_link)
+            event.stop()
+            return
         try:
             await super()._on_mouse_up(event)
         finally:
@@ -692,7 +705,14 @@ class ResultsArea(TextArea):
     def on_unmount(self) -> None:
         """Release mouse capture if results are redrawn during interaction."""
 
+        self._pressed_delivery_lookup_link = None
         self._end_mouse_interaction()
+
+    def _open_delivery_lookup(self, link: _DeliveryLookupLink) -> None:
+        app = getattr(self, "app", None)
+        open_lookup = getattr(app, "_open_delivery_lookup", None)
+        if open_lookup is not None:
+            open_lookup(link)
 
     async def _on_mouse_move(
         self,

--- a/test/test_ui_bindings.py
+++ b/test/test_ui_bindings.py
@@ -938,6 +938,80 @@ async def test_results_area_ignores_middle_mouse_down(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_delivery_lookup_link_activates_on_mouse_up(tmp_path):
+    logs_dir = tmp_path / "logs"
+    write_sample_logs(logs_dir)
+    app = LogBrowser(logs_dir=logs_dir)
+    link = _DeliveryLookupLink(4, "67518204", date(2024, 1, 1))
+
+    class Event:
+        button = 1
+        stopped = False
+
+        def stop(self) -> None:
+            self.stopped = True
+
+    async with app.run_test() as pilot:
+        app._show_step_results()
+        await pilot.pause()
+        area = app.wizard.query_one(ResultsArea)
+        opened: list[_DeliveryLookupLink] = []
+        area._delivery_lookup_link_at_event = (  # type: ignore[method-assign]
+            lambda _event: link
+        )
+        area._open_delivery_lookup = (  # type: ignore[method-assign]
+            lambda active_link: opened.append(active_link)
+        )
+
+        down_event = Event()
+        await area._on_mouse_down(down_event)  # type: ignore[arg-type]
+
+        assert opened == []
+        assert down_event.stopped is True
+
+        up_event = Event()
+        await area._on_mouse_up(up_event)  # type: ignore[arg-type]
+
+        assert opened == [link]
+        assert up_event.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_delivery_lookup_link_mouse_up_elsewhere_cancels(tmp_path):
+    logs_dir = tmp_path / "logs"
+    write_sample_logs(logs_dir)
+    app = LogBrowser(logs_dir=logs_dir)
+    link = _DeliveryLookupLink(4, "67518204", date(2024, 1, 1))
+
+    class Event:
+        button = 1
+        stopped = False
+
+        def stop(self) -> None:
+            self.stopped = True
+
+    async with app.run_test() as pilot:
+        app._show_step_results()
+        await pilot.pause()
+        area = app.wizard.query_one(ResultsArea)
+        opened: list[_DeliveryLookupLink] = []
+        lookup_results = [link, None]
+        area._delivery_lookup_link_at_event = (  # type: ignore[method-assign]
+            lambda _event: lookup_results.pop(0)
+        )
+        area._open_delivery_lookup = (  # type: ignore[method-assign]
+            lambda active_link: opened.append(active_link)
+        )
+
+        await area._on_mouse_down(Event())  # type: ignore[arg-type]
+        up_event = Event()
+        await area._on_mouse_up(up_event)  # type: ignore[arg-type]
+
+        assert opened == []
+        assert up_event.stopped is True
+
+
+@pytest.mark.asyncio
 async def test_clear_wizard_releases_results_mouse_capture(tmp_path):
     logs_dir = tmp_path / "logs"
     write_sample_logs(logs_dir)


### PR DESCRIPTION
## Summary
Move Delivery lookup link activation from mouse-down to mouse-up.

## What changed
- Record the pressed Delivery lookup link on mouse-down without starting a search.
- Activate the Delivery lookup only on mouse-up over the same link.
- Cancel the pending link if mouse-up happens elsewhere.
- Keep the previous stale-capture defenses for non-left mouse input, redraw, and unmount cleanup.

## Why
Starting the Delivery lookup during mouse-down can redraw the results view while TextArea mouse interaction is still active. Activating on mouse-up follows normal click semantics and avoids starting the search in the risky part of the mouse event lifecycle.

## Expected result
Clicking a Delivery lookup link should no longer leave mouse capture or hover behavior stuck after the Delivery results screen opens.

## Scope
Follow-up hotfix for the Delivery lookup mouse interaction issue.

## Validation
- .venv/bin/python -m pytest -q
- .venv/bin/python -m unittest discover test
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mypy sm_logtool
