### PR TITLE
Prepare v1.0.3 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sm-logtool"
-version = "1.0.2"
+version = "1.0.3"
 description = "Interactive TUI and non-interactive CLI helper for exploring SmarterMail logs on Linux servers"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sm_logtool/__init__.py
+++ b/sm_logtool/__init__.py
@@ -4,4 +4,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"


### PR DESCRIPTION
## Summary
Prepare package metadata for publishing sm-logtool v1.0.3.

## What changed
- Bump pyproject.toml project version from 1.0.2 to 1.0.3.
- Bump sm_logtool.__version__ from 1.0.2 to 1.0.3.
- Confirm no remaining tracked 1.0.2, 1.0.1, or 1.0.0 references exist in searched code/docs paths.

## Why
This aligns tracked package version metadata before publishing the hotfix release for PRs #104 and #105.

## Expected result
Builds and --version metadata report 1.0.3 once this release-prep branch is merged.

## Scope
Release preparation only. Includes the already-merged mouse-capture and mouse-up activation hotfixes from PRs #104 and #105 in the upcoming v1.0.3 release.

## Validation
- rg -n "1\.0\.2|1\.0\.3|1\.0\.1|1\.0\.0" pyproject.toml sm_logtool README.md docs test scripts
- .venv/bin/python -m pytest -q test/test_line_length_policy.py test/test_public_docstrings.py test/test_cli.py::test_main_version_flag_prints_version_and_exits_zero
- .venv/bin/python scripts/check_release_defaults.py
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mypy sm_logtool
- .venv/bin/python -m pytest -q
- .venv/bin/python -m unittest discover test
