### PR TITLE
Enable keyboard activation for delivery links

### DIFF
--- a/sm_logtool/ui/app.py
+++ b/sm_logtool/ui/app.py
@@ -714,6 +714,19 @@ class ResultsArea(TextArea):
         if open_lookup is not None:
             open_lookup(link)
 
+    async def _on_key(
+        self,
+        event: events.Key,
+    ) -> None:  # pragma: no cover - UI behaviour
+        if event.key == "enter":
+            link = self._delivery_lookup_link_at_cursor()
+            if link is not None:
+                self._open_delivery_lookup(link)
+                event.stop()
+                event.prevent_default()
+                return
+        await super()._on_key(event)
+
     async def _on_mouse_move(
         self,
         event: events.MouseMove,
@@ -740,6 +753,13 @@ class ResultsArea(TextArea):
     ) -> _DeliveryLookupLink | None:
         try:
             row, _column = self.get_target_document_location(event)
+        except Exception:
+            return None
+        return self._delivery_lookup_links.get(row)
+
+    def _delivery_lookup_link_at_cursor(self) -> _DeliveryLookupLink | None:
+        try:
+            row, _column = self.cursor_location
         except Exception:
             return None
         return self._delivery_lookup_links.get(row)

--- a/test/test_ui_bindings.py
+++ b/test/test_ui_bindings.py
@@ -1012,6 +1012,44 @@ async def test_delivery_lookup_link_mouse_up_elsewhere_cancels(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_delivery_lookup_link_activates_on_enter(tmp_path):
+    logs_dir = tmp_path / "logs"
+    write_sample_logs(logs_dir)
+    app = LogBrowser(logs_dir=logs_dir)
+    link = _DeliveryLookupLink(4, "67518204", date(2024, 1, 1))
+
+    class Event:
+        key = "enter"
+        stopped = False
+        prevented = False
+
+        def stop(self) -> None:
+            self.stopped = True
+
+        def prevent_default(self) -> None:
+            self.prevented = True
+
+    async with app.run_test() as pilot:
+        app._show_step_results()
+        await pilot.pause()
+        area = app.wizard.query_one(ResultsArea)
+        area.text = "\n".join(f"line {index}" for index in range(6))
+        area.set_delivery_lookup_links([link])
+        area.move_cursor((link.row, 0))
+        opened: list[_DeliveryLookupLink] = []
+        area._open_delivery_lookup = (  # type: ignore[method-assign]
+            lambda active_link: opened.append(active_link)
+        )
+        event = Event()
+
+        await area._on_key(event)  # type: ignore[arg-type]
+
+        assert opened == [link]
+        assert event.stopped is True
+        assert event.prevented is True
+
+
+@pytest.mark.asyncio
 async def test_clear_wizard_releases_results_mouse_capture(tmp_path):
     logs_dir = tmp_path / "logs"
     write_sample_logs(logs_dir)


### PR DESCRIPTION
## Summary
Add keyboard activation for Delivery lookup links in TUI results.

## What changed
- Pressing Enter on a Delivery lookup link row now opens the associated same-day Delivery log search.
- Non-link Enter behavior continues to fall through to the normal results TextArea handling.
- Add regression coverage for Enter activation on the selected link row.

## Why
The Delivery lookup link was mouse-accessible but not keyboard-accessible. Users could move the cursor to the link row with arrow keys, but Space, right arrow, and Enter did not activate it. Enter is the expected activation key in this context.

## Expected result
Keyboard users can move to Find this message in the Delivery Log and press Enter to run the Delivery lookup.

## Scope
Accessibility/usability fix for the SMTP-to-Delivery lookup workflow.

## Validation
- .venv/bin/python -m pytest -q
- .venv/bin/python -m unittest discover test
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mypy sm_logtool
